### PR TITLE
fix: define CWDriverRegistry::REGISTRY — null deref bootloop after DMA setup

### DIFF
--- a/firmware/src/CWClockfaceRegistry.cpp
+++ b/firmware/src/CWClockfaceRegistry.cpp
@@ -1,0 +1,15 @@
+#include <CWClockfaceDriver.h>
+
+// Definition of the static registry array declared in CWClockfaceDriver.h.
+// Must live here (in main/src) so all clockface component symbols are visible
+// to the linker at this point. A missing definition causes REGISTRY to resolve
+// to address 0x0, producing a LoadProhibited crash immediately after DMA setup.
+
+const CWClockfaceDriver* CWDriverRegistry::REGISTRY[CWDriverRegistry::COUNT] = {
+    &cf_mario,       // index 0 — cw-cf-0x01
+    &cf_words,       // index 1 — cw-cf-0x02
+    &cf_worldmap,    // index 2 — cw-cf-0x03
+    &cf_castlevania, // index 3 — cw-cf-0x04
+    &cf_pacman,      // index 4 — cw-cf-0x05
+    &cf_pokedex,     // index 5 — cw-cf-0x06
+};


### PR DESCRIPTION
## Summary

- `CWDriverRegistry::REGISTRY[]` was declared in `CWClockfaceDriver.h` but never defined in any translation unit
- The linker resolved the symbol to address `0x0`, so every `get()` / `switchTo()` call read from `0x00000000`
- Result: deterministic `LoadProhibited` crash on Core 1 immediately after `I2S-DMA: DMA setup completed`
- Fix: define the array in `firmware/src/CWClockfaceRegistry.cpp` where all six clockface component symbols are visible to the linker

## Root cause

```
EXCVADDR: 0x00000000   ← reading from address zero
EXCCAUSE: 0x0000001c   ← LoadProhibited
```
Crash was 100% reproducible on every boot across both OTA partitions.

## Test plan

- [ ] Native tests pass
- [ ] Firmware builds without linker errors
- [ ] Device boots without bootloop
- [ ] All 6 clockfaces accessible via WebUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)