### PR TITLE
fix: register dma_display with Locator before first StatusController call

### DIFF
--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -13,6 +13,7 @@ static const CWClockfaceDriver* currentFace = nullptr;
 #include <CWPreferences.h>
 #include <CWWebServer.h>
 #include <StatusController.h>
+#include <Locator.h>
 #include <CWMqtt.h>
 
 #define MIN_BRIGHT_DISPLAY_ON 4
@@ -204,6 +205,11 @@ void setup()
 
   displaySetup(p->ledColorOrder, p->reversePhase, p->displayBright,
                p->displayRotation, p->driver, p->i2cSpeed, p->E_pin);
+
+  // Register display with Locator so StatusController (and any other lib) can reach it.
+  // Must happen before clockwiseLogo() — Locator::_display starts null; any call before
+  // this line crashes with LoadProhibited (EXCVADDR=0x00000000).
+  Locator::provide(dma_display);
 
   // v3: note target clockface — setup() called after cwDateTime is ready
   CWDriverRegistry::get(p->clockFaceIndex); // validate index early


### PR DESCRIPTION
## Summary

- \`Locator::_display\` is initialised to \`null\` at startup and is never populated until an explicit \`Locator::provide()\` call is made.
- \`StatusController::clockwiseLogo()\` and every other display helper call \`Locator::getDisplay()\` without a null-check, so the very first display operation after boot dereferenced a null pointer.
- This produced a repeatable \`LoadProhibited\` exception with \`EXCVADDR: 0x00000000\` — a crash that survived the v2.6.1 release because the registration call was simply missing.
- The fix is a single \`Locator::provide(dma_display)\` call placed immediately after \`displaySetup()\` in \`setup()\`, plus the required \`#include <Locator.h>\`. This ensures the display pointer is registered before any \`StatusController\` method is invoked.

## Test plan

- [ ] Native tests pass
- [ ] Firmware builds cleanly under ESP-IDF
- [ ] OTA flash successful on device
- [ ] Device boots without \`LoadProhibited\` / \`EXCVADDR: 0x00000000\`
- [ ] Clockface renders on first boot after flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)