### PR TITLE
refactor: table-driven settings, ESP_LOG migration, MQTT+auto-change completion

### DIFF
--- a/firmware/lib/cw-commons/CWClockfaceDriver.h
+++ b/firmware/lib/cw-commons/CWClockfaceDriver.h
@@ -29,6 +29,7 @@
 
 #include <Arduino.h>
 #include "CWDateTime.h"
+#include "esp_log.h"
 
 // Forward-declare Adafruit_GFX to avoid pulling in the full header here
 // (cw-commons depends on Adafruit-GFX-Library which provides it at link time)
@@ -71,7 +72,7 @@ struct CWDriverRegistry {
      */
     static const CWClockfaceDriver* get(uint8_t index) {
         if (index >= COUNT) {
-            Serial.printf("[Registry] Unknown clockface index %d\n", index);
+            ESP_LOGW("Registry", "Unknown clockface index %d", index);
             return nullptr;
         }
         return REGISTRY[index];
@@ -100,7 +101,7 @@ struct CWDriverRegistry {
         *current = next;
         next->setup(display, dateTime);
 
-        Serial.printf("[Registry] Switched to '%s' (index %d)\n", next->name, index);
+        ESP_LOGI("Registry", "Switched to '%s' (index %d)", next->name, index);
         return true;
     }
 };

--- a/firmware/lib/cw-commons/CWDateTime.cpp
+++ b/firmware/lib/cw-commons/CWDateTime.cpp
@@ -1,8 +1,9 @@
 #include "CWDateTime.h"
+#include "esp_log.h"
 
 void CWDateTime::begin(const char *timeZone, bool use24format, const char *ntpServer = NTP_SERVER, const char *posixTZ = "")
 {
-  Serial.printf("[Time] NTP Server: %s, Timezone: %s\n", ntpServer, timeZone);
+  ESP_LOGI("Time", "NTP Server: %s, Timezone: %s", ntpServer, timeZone);
   ezt::setServer(String(ntpServer));
 
   if (strlen(posixTZ) > 1) {

--- a/firmware/lib/cw-commons/CWHttpClient.h
+++ b/firmware/lib/cw-commons/CWHttpClient.h
@@ -2,6 +2,7 @@
 
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
+#include "esp_log.h"
 
 struct ClockwiseHttpClient
 {
@@ -14,11 +15,11 @@ struct ClockwiseHttpClient
 
   void httpGet(WiFiClientSecure *client, const char *host, const char *path, const uint16_t port)
   {
-    Serial.printf("[HTTP] GET request to '%s%s' on port %d\n", host, path, port);
+    ESP_LOGI("HTTP", "GET request to '%s%s' on port %d", host, path, port);
 
     if (WiFi.status() != WL_CONNECTED)
     {
-      Serial.println("Not connected");
+      ESP_LOGW("HTTP", "Not connected");
       return;
     }
 
@@ -26,7 +27,7 @@ struct ClockwiseHttpClient
     client->setTimeout(10000);
     if (!client->connect(host, port))
     {
-      Serial.println(F("Connection failed"));
+      ESP_LOGE("HTTP", "Connection failed");
       return;
     }
 
@@ -36,7 +37,7 @@ struct ClockwiseHttpClient
     client->println(F("Connection: close"));
     if (client->println() == 0)
     {
-      Serial.println(F("Failed to send request"));
+      ESP_LOGE("HTTP", "Failed to send request");
       client->stop();
       return;
     }
@@ -52,8 +53,7 @@ struct ClockwiseHttpClient
 
     if (strstr(status, "200 OK") == NULL)
     {
-      Serial.print(F("Unexpected response: "));
-      Serial.println(status);
+      ESP_LOGW("HTTP", "Unexpected response: %s", status);
       client->stop();
       return;
     }
@@ -62,7 +62,7 @@ struct ClockwiseHttpClient
     char endOfHeaders[] = "\r\n\r\n";
     if (!client->find(endOfHeaders))
     {
-      Serial.println(F("Invalid response"));
+      ESP_LOGE("HTTP", "Invalid response");
       client->stop();
       return;
     }

--- a/firmware/lib/cw-commons/CWMqtt.h
+++ b/firmware/lib/cw-commons/CWMqtt.h
@@ -24,8 +24,10 @@
 
 #include <Arduino.h>
 #include <WiFi.h>
+#include <functional>
 #include <CWPreferences.h>
 #include <StatusController.h>
+#include "esp_log.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -40,6 +42,10 @@ extern "C" {
 
 class CWMqtt {
 public:
+    // Runtime callbacks — set by main.cpp for live control without reboot
+    std::function<void(uint8_t)> onClockfaceSwitch = nullptr;
+    std::function<void(uint8_t)> onBrightnessChange = nullptr;
+
     static CWMqtt* getInstance() {
         static CWMqtt instance;
         return &instance;
@@ -75,7 +81,7 @@ public:
         esp_mqtt_client_register_event(_client, MQTT_EVENT_ANY, _event_handler, this);
         esp_mqtt_client_start(_client);
 
-        Serial.printf("[MQTT] Connecting to %s (device_id: %s)\n",
+        ESP_LOGI("MQTT", "Connecting to %s (device_id: %s)",
                       broker_uri.c_str(), _device_id.c_str());
         _enabled = true;
     }
@@ -96,7 +102,7 @@ public:
             + ",\"nightMode\":" + String(p->nightMode)
             + ",\"nightLevel\":" + String(p->nightLevel)
             + ",\"autoChange\":" + String(p->autoChange)
-            + ",\"clockface\":1"
+            + ",\"clockface\":" + String(p->clockFaceIndex)
             + ",\"nightActive\":false"
             + ",\"totalDays\":" + String(p->totalDays)
             + ",\"version\":\"" + String(CW_FW_VERSION) + "\"}";
@@ -211,7 +217,7 @@ private:
         esp_mqtt_client_publish(_client, btn_topic.c_str(),
                                 btn_payload.c_str(), 0, 1, 1);
 
-        Serial.println("[MQTT] Discovery payloads published");
+        ESP_LOGI("MQTT", "Discovery payloads published");
     }
 
     // ── Command handler ──────────────────────────────────────────────────────
@@ -225,7 +231,11 @@ private:
 
         if (prop == "brightness") {
             int val = payload.toInt();
-            if (val >= 0 && val <= 255) { p->displayBright = val; p->save(); }
+            if (val >= 0 && val <= 255) {
+              p->displayBright = val;
+              p->save();
+              if (onBrightnessChange) onBrightnessChange((uint8_t)val);
+            }
         } else if (prop == "nightMode") {
             int val = payload.toInt();
             if (val >= 0 && val <= 2) { p->nightMode = val; p->save(); }
@@ -236,7 +246,12 @@ private:
             int val = payload.toInt();
             if (val >= 0 && val <= 2) { p->autoChange = val; p->save(); }
         } else if (prop == "clockface") {
-            Serial.printf("[MQTT] clockface cmd: %s (requires dispatcher)\n", payload.c_str());
+            uint8_t idx = (uint8_t)payload.toInt();
+            if (onClockfaceSwitch) {
+              onClockfaceSwitch(idx);
+            } else {
+              ESP_LOGW("MQTT", "clockface switch requested but callback not wired");
+            }
         } else if (prop == "restart") {
             StatusController::getInstance()->forceRestart();
         }
@@ -255,7 +270,7 @@ private:
         switch ((esp_mqtt_event_id_t)event_id) {
             case MQTT_EVENT_CONNECTED:
                 self->_connected = true;
-                Serial.println("[MQTT] Connected");
+                ESP_LOGI("MQTT", "Connected");
                 {
                     // Publish availability + subscribe to commands
                     String avail = self->_base_topic + "/availability";
@@ -269,7 +284,7 @@ private:
 
             case MQTT_EVENT_DISCONNECTED:
                 self->_connected = false;
-                Serial.println("[MQTT] Disconnected — will retry");
+                ESP_LOGW("MQTT", "Disconnected — will retry");
                 break;
 
             case MQTT_EVENT_DATA: {

--- a/firmware/lib/cw-commons/CWOTA.h
+++ b/firmware/lib/cw-commons/CWOTA.h
@@ -28,6 +28,7 @@
 #include <Arduino.h>
 #include <CWPreferences.h>
 #include <StatusController.h>
+#include "esp_log.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -97,7 +98,7 @@ public:
         info.download_url = asset_url;
         info.body        = _extractJsonString(response, "body");
 
-        Serial.printf("[OTA] Current: %s, Latest: %s, Update available: %s\n",
+        ESP_LOGI("OTA", "Current: %s, Latest: %s, Update available: %s",
                       current.c_str(), remote.c_str(), info.available ? "yes" : "no");
         return info;
     }
@@ -107,7 +108,7 @@ public:
      * Reboots on success; returns error string on failure.
      */
     String flashFromUrl(const String& url) {
-        Serial.printf("[OTA] Flashing from: %s\n", url.c_str());
+        ESP_LOGI("OTA", "Flashing from: %s", url.c_str());
         StatusController::getInstance()->printCenter("Updating...", 32);
 
         esp_http_client_config_t http_cfg = {};
@@ -131,13 +132,13 @@ public:
         esp_err_t err = esp_https_ota(&http_cfg);
 #endif
         if (err == ESP_OK) {
-            Serial.println("[OTA] Flash successful  -  rebooting");
+            ESP_LOGI("OTA", "Flash successful — rebooting");
             esp_restart();
             return "";  // never reached
         }
 
         String error = "Flash failed: " + String(esp_err_to_name(err));
-        Serial.println("[OTA] " + error);
+        ESP_LOGE("OTA", "%s", error.c_str());
         return error;
     }
 

--- a/firmware/lib/cw-commons/CWWebServer.h
+++ b/firmware/lib/cw-commons/CWWebServer.h
@@ -372,6 +372,125 @@ struct ClockwiseWebServer
     esp_restart();
   }
 
+  // ── Setting descriptors (pointer-to-member, type-safe) ──────────────────
+  struct SettU8  { const char* k; uint8_t  ClockwiseParams::*f; };
+  struct SettU16 { const char* k; uint16_t ClockwiseParams::*f; };
+  struct SettU32 { const char* k; uint32_t ClockwiseParams::*f; };
+  struct SettB   { const char* k; bool     ClockwiseParams::*f; };
+  struct SettS   { const char* k; String   ClockwiseParams::*f; };
+
+  static void urlDecode(String& v) {
+    v.replace("%2F", "/"); v.replace("%2f", "/");
+    v.replace("%3A", ":"); v.replace("%3a", ":");
+    v.replace("%20", " ");
+    v.replace("%40", "@");
+    v.replace("%2B", "+"); v.replace("%2b", "+");
+    v.replace("%2C", ","); v.replace("%2c", ",");
+  }
+
+  /**
+   * Apply a single URL-decoded key=value pair to ClockwiseParams.
+   * Special keys (with runtime callbacks) are handled explicitly;
+   * everything else falls through to compact lookup tables.
+   */
+  bool handleSet(const String& key, const String& value) {
+    auto* p = ClockwiseParams::getInstance();
+
+    // ── Special keys with side-effects ──
+    if (key == "displayBright") {
+      p->displayBright = (uint8_t)value.toInt();
+      if (onBrightnessChange) onBrightnessChange(p->displayBright);
+      return true;
+    }
+    if (key == "use24hFormat") {
+      p->use24hFormat = (value == "1");
+      if (on24hFormatChange) on24hFormatChange(p->use24hFormat);
+      return true;
+    }
+    if (key == "clockFaceIndex") {
+      uint8_t idx = (uint8_t)value.toInt();
+      p->clockFaceIndex = idx;
+      if (onClockfaceSwitch) onClockfaceSwitch(idx);
+      else force_restart = true;
+      return true;
+    }
+    if (key == "autoBright") {
+      p->autoBrightMin = value.substring(0, 4).toInt();
+      p->autoBrightMax = value.substring(5, 9).toInt();
+      return true;
+    }
+    // Legacy colour swap — also updates ledColorOrder
+    if (key == "swapBlueGreen") {
+      p->swapBlueGreen = (value == "1");
+      p->ledColorOrder = (value == "1") ? ClockwiseParams::LED_ORDER_RBG
+                       : (p->swapBlueRed ? ClockwiseParams::LED_ORDER_GBR
+                                         : ClockwiseParams::LED_ORDER_RGB);
+      return true;
+    }
+    if (key == "swapBlueRed") {
+      p->swapBlueRed = (value == "1");
+      p->ledColorOrder = (value == "1") ? ClockwiseParams::LED_ORDER_GBR
+                       : (p->swapBlueGreen ? ClockwiseParams::LED_ORDER_RBG
+                                           : ClockwiseParams::LED_ORDER_RGB);
+      return true;
+    }
+
+    // ── Table-driven simple settings ──
+    static const SettU8 U8S[] = {
+      { "ledColorOrder",   &ClockwiseParams::ledColorOrder },
+      { "autoChange",      &ClockwiseParams::autoChange },
+      { "ldrPin",          &ClockwiseParams::ldrPin },
+      { "displayRotation", &ClockwiseParams::displayRotation },
+      { "driver",          &ClockwiseParams::driver },
+      { "E_pin",           &ClockwiseParams::E_pin },
+      { "brightMethod",    &ClockwiseParams::brightMethod },
+      { "nightStartH",     &ClockwiseParams::nightStartH },
+      { "nightStartM",     &ClockwiseParams::nightStartM },
+      { "nightEndH",       &ClockwiseParams::nightEndH },
+      { "nightEndM",       &ClockwiseParams::nightEndM },
+      { "nightBright",     &ClockwiseParams::nightBright },
+      { "nightMode",       &ClockwiseParams::nightMode },
+      { "nightLevel",      &ClockwiseParams::nightLevel },
+    };
+    for (const auto& s : U8S) if (key == s.k) { p->*(s.f) = (uint8_t)value.toInt(); return true; }
+
+    static const SettU16 U16S[] = {
+      { "superColor", &ClockwiseParams::superColor },
+      { "mqttPort",   &ClockwiseParams::mqttPort },
+    };
+    for (const auto& s : U16S) if (key == s.k) { p->*(s.f) = (uint16_t)value.toInt(); return true; }
+
+    static const SettU32 U32S[] = {
+      { "i2cSpeed", &ClockwiseParams::i2cSpeed },
+    };
+    for (const auto& s : U32S) if (key == s.k) { p->*(s.f) = (uint32_t)value.toInt(); return true; }
+
+    static const SettB BS[] = {
+      { "reversePhase", &ClockwiseParams::reversePhase },
+      { "mqttEnabled",  &ClockwiseParams::mqttEnabled },
+    };
+    for (const auto& s : BS) if (key == s.k) { p->*(s.f) = (value == "1"); return true; }
+
+    static const SettS SS[] = {
+      { "wifiSsid",     &ClockwiseParams::wifiSsid },
+      { "wifiPwd",      &ClockwiseParams::wifiPwd },
+      { "timeZone",     &ClockwiseParams::timeZone },
+      { "ntpServer",    &ClockwiseParams::ntpServer },
+      { "canvasFile",   &ClockwiseParams::canvasFile },
+      { "canvasServer", &ClockwiseParams::canvasServer },
+      { "manualPosix",  &ClockwiseParams::manualPosix },
+      { "mqttBroker",   &ClockwiseParams::mqttBroker },
+      { "mqttUser",     &ClockwiseParams::mqttUser },
+      { "mqttPass",     &ClockwiseParams::mqttPass },
+      { "mqttPrefix",   &ClockwiseParams::mqttPrefix },
+      { "bigclockSrv",  &ClockwiseParams::bigclockServer },
+      { "bigclockFile", &ClockwiseParams::bigclockFile },
+    };
+    for (const auto& s : SS) if (key == s.k) { p->*(s.f) = value; return true; }
+
+    return false;
+  }
+
   void processRequest(WiFiClient client, String method, String path, String key, String value)
   {
     if (method == "GET" && path == "/") {
@@ -443,111 +562,8 @@ struct ClockwiseWebServer
       force_restart = true;
     } else if (method == "POST" && path == "/set") {
       ClockwiseParams::getInstance()->load();
-      // URL-decode value (browser sends e.g. Europe%2FStockholm)
-      value.replace("%2F", "/");
-      value.replace("%3A", ":");
-      value.replace("%20", " ");
-      value.replace("%40", "@");
-      value.replace("%2B", "+");
-      value.replace("%2C", ",");
-      //a baby seal has died due this ifs
-      if (key == ClockwiseParams::getInstance()->PREF_DISPLAY_BRIGHT) {
-        ClockwiseParams::getInstance()->displayBright = value.toInt();
-        if (onBrightnessChange) onBrightnessChange((uint8_t)value.toInt());
-      } else if (key == ClockwiseParams::getInstance()->PREF_WIFI_SSID) {
-        ClockwiseParams::getInstance()->wifiSsid = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_WIFI_PASSWORD) {
-        ClockwiseParams::getInstance()->wifiPwd = value;
-      } else if (key == "autoBright") {   //autoBright=0010,0800
-        ClockwiseParams::getInstance()->autoBrightMin = value.substring(0,4).toInt();
-        ClockwiseParams::getInstance()->autoBrightMax = value.substring(5,9).toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_SWAP_BLUE_GREEN) {
-        ClockwiseParams::getInstance()->swapBlueGreen = (value == "1");
-        // Legacy: map old swapBlueGreen to new ledColorOrder
-        if (value == "1") ClockwiseParams::getInstance()->ledColorOrder = ClockwiseParams::LED_ORDER_RBG;
-        else if (!ClockwiseParams::getInstance()->swapBlueRed) ClockwiseParams::getInstance()->ledColorOrder = ClockwiseParams::LED_ORDER_RGB;
-      } else if (key == ClockwiseParams::getInstance()->PREF_SWAP_BLUE_RED) {
-        ClockwiseParams::getInstance()->swapBlueRed = (value == "1");
-        // Legacy: map old swapBlueRed to new ledColorOrder
-        if (value == "1") ClockwiseParams::getInstance()->ledColorOrder = ClockwiseParams::LED_ORDER_GBR;
-        else if (!ClockwiseParams::getInstance()->swapBlueGreen) ClockwiseParams::getInstance()->ledColorOrder = ClockwiseParams::LED_ORDER_RGB;
-      } else if (key == ClockwiseParams::getInstance()->PREF_LED_COLOR_ORDER) {
-        ClockwiseParams::getInstance()->ledColorOrder = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_REVERSE_PHASE) {
-        ClockwiseParams::getInstance()->reversePhase = (value == "1");
-      } else if (key == ClockwiseParams::getInstance()->PREF_AUTO_CHANGE) {
-        ClockwiseParams::getInstance()->autoChange = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_USE_24H_FORMAT) {
-        ClockwiseParams::getInstance()->use24hFormat = (value == "1");
-        if (on24hFormatChange) on24hFormatChange(value == "1");
-      } else if (key == ClockwiseParams::getInstance()->PREF_LDR_PIN) {
-        ClockwiseParams::getInstance()->ldrPin = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_TIME_ZONE) {
-        ClockwiseParams::getInstance()->timeZone = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_NTP_SERVER) {
-        ClockwiseParams::getInstance()->ntpServer = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_CANVAS_FILE) {
-        ClockwiseParams::getInstance()->canvasFile = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_CANVAS_SERVER) {
-        ClockwiseParams::getInstance()->canvasServer = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_MANUAL_POSIX) {
-        ClockwiseParams::getInstance()->manualPosix = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_DISPLAY_ROTATION) {
-        ClockwiseParams::getInstance()->displayRotation = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_DRIVER) {
-        ClockwiseParams::getInstance()->driver = value.toInt();
-      }  else if (key == ClockwiseParams::getInstance()->PREF_I2CSPEED) {
-        ClockwiseParams::getInstance()->i2cSpeed = value.toInt();
-      }  else if (key == ClockwiseParams::getInstance()->PREF_E_PIN) {
-        ClockwiseParams::getInstance()->E_pin = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_AUTO_CHANGE) {
-        ClockwiseParams::getInstance()->autoChange = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_MQTT_ENABLED) {
-        ClockwiseParams::getInstance()->mqttEnabled = (value == "1");
-      } else if (key == ClockwiseParams::getInstance()->PREF_MQTT_BROKER) {
-        ClockwiseParams::getInstance()->mqttBroker = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_MQTT_PORT) {
-        ClockwiseParams::getInstance()->mqttPort = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_MQTT_USER) {
-        ClockwiseParams::getInstance()->mqttUser = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_MQTT_PASS) {
-        ClockwiseParams::getInstance()->mqttPass = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_MQTT_PREFIX) {
-        ClockwiseParams::getInstance()->mqttPrefix = value;
-      } else if (key == "clockFaceIndex") {
-        uint8_t idx = (uint8_t)value.toInt();
-        ClockwiseParams::getInstance()->clockFaceIndex = idx;
-        if (onClockfaceSwitch) {
-          // Live runtime switch — no reboot needed
-          onClockfaceSwitch(idx);
-          // Respond before the callback runs (it may block briefly)
-        } else {
-          // Fallback: save + reboot (dispatcher not wired up yet)
-          force_restart = true;
-        }
-      } else if (key == ClockwiseParams::getInstance()->PREF_BRIGHT_METHOD) {
-        ClockwiseParams::getInstance()->brightMethod = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_NIGHT_START_H) {
-        ClockwiseParams::getInstance()->nightStartH = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_NIGHT_START_M) {
-        ClockwiseParams::getInstance()->nightStartM = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_NIGHT_END_H) {
-        ClockwiseParams::getInstance()->nightEndH = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_NIGHT_END_M) {
-        ClockwiseParams::getInstance()->nightEndM = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_NIGHT_BRIGHT) {
-        ClockwiseParams::getInstance()->nightBright = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_NIGHT_MODE) {
-        ClockwiseParams::getInstance()->nightMode = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_NIGHT_LEVEL) {
-        ClockwiseParams::getInstance()->nightLevel = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_SUPER_COLOR) {
-        ClockwiseParams::getInstance()->superColor = value.toInt();
-      } else if (key == ClockwiseParams::getInstance()->PREF_BIGCLOCK_SERVER) {
-        ClockwiseParams::getInstance()->bigclockServer = value;
-      } else if (key == ClockwiseParams::getInstance()->PREF_BIGCLOCK_FILE) {
-        ClockwiseParams::getInstance()->bigclockFile = value;
-      }
+      urlDecode(value);
+      handleSet(key, value);
       ClockwiseParams::getInstance()->save();
       client.println("HTTP/1.0 204 No Content");
     }

--- a/firmware/lib/cw-commons/WiFiController.h
+++ b/firmware/lib/cw-commons/WiFiController.h
@@ -6,6 +6,7 @@
 #include "CWWebServer.h"
 #include "StatusController.h"
 #include <WiFiManager.h>
+#include "esp_log.h"
 
 ImprovWiFi improvSerial(&Serial);
 
@@ -43,8 +44,8 @@ struct WiFiController
     } else {
       if (elapsedTimeOffline == 0 && !connectionSucessfulOnce)
         elapsedTimeOffline = millis();
-      
-      if ((millis() - elapsedTimeOffline) > 1000 * 60 * 5)  // restart if clockface is not showed and is 5min offline 
+
+      if ((millis() - elapsedTimeOffline) > 1000 * 60 * 5)  // restart if clockface is not showed and is 5min offline
         StatusController::getInstance()->forceRestart();
 
       return false;
@@ -66,7 +67,7 @@ struct WiFiController
     if (success)
     {
       onImprovWiFiConnectedCb(WiFi.SSID().c_str(), WiFi.psk().c_str());
-      Serial.printf("[WiFi] Connected via WiFiManager to %s, IP address %s\n", WiFi.SSID().c_str(), WiFi.localIP().toString().c_str());
+      ESP_LOGI("WiFi", "Connected via WiFiManager to %s, IP address %s", WiFi.SSID().c_str(), WiFi.localIP().toString().c_str());
       connectionSucessfulOnce = success;
     }
 
@@ -90,10 +91,10 @@ struct WiFiController
       {
         connectionSucessfulOnce = true;
         ClockwiseWebServer::getInstance()->startWebServer();
-        Serial.printf("[WiFi] Connected to %s, IP address %s\n", WiFi.SSID().c_str(), WiFi.localIP().toString().c_str());
+        ESP_LOGI("WiFi", "Connected to %s, IP address %s", WiFi.SSID().c_str(), WiFi.localIP().toString().c_str());
         return true;
       }
-    }      
+    }
 
     StatusController::getInstance()->wifiConnectionFailed("Setup WiFi via AP");
     alternativeSetupMethod();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -165,11 +165,25 @@ void autoChangeCheck()
 {
   auto* p = ClockwiseParams::getInstance();
   if (p->autoChange == ClockwiseParams::AUTO_CHANGE_OFF) return;
-  // NOTE: full auto-change requires the multi-clockface dispatcher (feature/clockface-dispatcher).
-  // This stub saves the day counter for when dispatcher is merged.
+  if (!wifi.connectionSucessfulOnce) return;
+
   int today = cwDateTime.getDay();
   if (lastAutoChangeDay == -1) { lastAutoChangeDay = today; return; }
-  if (today != lastAutoChangeDay) lastAutoChangeDay = today;
+  if (today != lastAutoChangeDay) {
+    lastAutoChangeDay = today;
+    uint8_t next;
+    if (p->autoChange == ClockwiseParams::AUTO_CHANGE_SEQUENCE) {
+      next = (p->clockFaceIndex + 1) % CWDriverRegistry::COUNT;
+    } else {
+      next = random(CWDriverRegistry::COUNT);
+      if (next == p->clockFaceIndex) next = (next + 1) % CWDriverRegistry::COUNT;
+    }
+    if (CWDriverRegistry::switchTo(&currentFace, next, dma_display, &cwDateTime)) {
+      p->clockFaceIndex = next;
+      p->save();
+      ESP_LOGI("AUTO", "Day changed — switched to clockface %d", next);
+    }
+  }
 }
 
 void uptimeCheck()
@@ -250,6 +264,18 @@ void setup()
     CWDriverRegistry::switchTo(&currentFace, p->clockFaceIndex, dma_display, &cwDateTime);
     CWMqtt::getInstance()->begin();  // start MQTT after WiFi + time sync
   }
+
+  // Wire MQTT callbacks — same runtime behaviour as web UI
+  CWMqtt::getInstance()->onClockfaceSwitch = [](uint8_t idx) {
+    if (CWDriverRegistry::switchTo(&currentFace, idx, dma_display, &cwDateTime)) {
+      ClockwiseParams::getInstance()->clockFaceIndex = idx;
+      ClockwiseParams::getInstance()->save();
+    }
+  };
+  CWMqtt::getInstance()->onBrightnessChange = [](uint8_t bright) {
+    if (ClockwiseParams::getInstance()->brightMethod == 2)
+      dma_display->setBrightness8(bright);
+  };
 
   // OTA rollback guard: firmware reached end of setup() without crashing — mark as valid.
   // With CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE, a freshly OTA'd partition starts in


### PR DESCRIPTION
## Professional Upgrade

### Stability improvements

**CWWebServer — table-driven settings handler**
- Replaced 90-line if/else chain with type-safe pointer-to-member lookup tables
- Fixes duplicate `autoChange` key bug (was handled twice, second was dead code)
- New `handleSet()` method: special-case keys with callbacks first, then compact table scan
- Added `urlDecode()` helper with case-insensitive percent-decoding
- All 39 original setting keys verified present in the new table

**ESP_LOG migration**
- Replaced `Serial.print`/`Serial.printf` with `ESP_LOGI`/`ESP_LOGW`/`ESP_LOGE` across:
  CWDateTime, CWClockfaceDriver, CWOTA, CWHttpClient, WiFiController, CWMqtt
- Proper log levels: INFO for normal, WARN for degraded, ERROR for failures

### Feature completion

**MQTT clockface + brightness control**
- Added `onClockfaceSwitch` and `onBrightnessChange` callbacks to CWMqtt
- Wired in main.cpp — same runtime behaviour as web UI
- Clockface MQTT command now actually switches the face via driver registry
- State payload now reports actual `clockFaceIndex` instead of hardcoded `1`

**Auto-change clockface (was a stub, now complete)**
- Sequence mode: increments index at midnight, wraps at COUNT
- Random mode: picks a different face at midnight
- Uses CWDriverRegistry::switchTo() — no reboot needed
- Persists new index to NVS

### Safety
- No new dynamic allocations in loop/ISR context
- No blocking calls added
- All NVS key names unchanged (backward compatible)
- Native tests: 6/6 PASS