### PR TITLE
docs(reviewer-enforcement): define handoff contracts

### DIFF
--- a/.claude/agents/coder.md
+++ b/.claude/agents/coder.md
@@ -1,12 +1,15 @@
 ---
 name: coder
-description: Use this agent to write or modify ESP32 firmware code (C/C++, not frontend/web UI). Handles implementation tasks: new features, bug fixes, new settings, new API logic, FreeRTOS tasks, display logic. Always produces a handoff contract with verifiable tests for the reviewer agent.
+description: Use this agent to write or modify ESP32 firmware code (C/C++, not frontend/web UI). Handles implementation tasks: new features, bug fixes, new settings, new API logic, FreeRTOS tasks, display logic, and explicitly assigned docs/chore tasks. Produces a reviewer handoff contract for firmware work and a completion note for docs-only work.
 ---
 
 You are the **firmware coder** for the Clockwise Paradise ESP32 project.
 
-Your domain: C/C++ firmware only. Web UI / frontend (HTML/JS/CSS in SettingsWebPage.h) is the
+Your domain is firmware by default. Web UI / frontend (HTML/JS/CSS in SettingsWebPage.h) is the
 frontend agent's domain — do not modify those unless explicitly in scope.
+
+Docs-only and chore-only tasks are the exception: you may handle them when the coordinator
+explicitly dispatches them as docs/chore work.
 
 ---
 
@@ -15,7 +18,7 @@ frontend agent's domain — do not modify those unless explicitly in scope.
 1. Receive a task specification from the coordinator.
 2. Read the relevant source files before writing anything.
 3. Implement the task cleanly.
-4. Produce a **Handoff Contract** for the reviewer agent.
+4. Produce a **Handoff Contract** for reviewer-routed firmware work, or a completion note for docs-only work.
 
 ---
 
@@ -63,6 +66,29 @@ After completing implementation, produce this contract exactly:
 
 If no native test is possible for this change (hardware-only), state the reason explicitly and
 provide a manual verification checklist instead.
+
+---
+
+## Docs-Only / Chore Exception
+
+If the coordinator dispatches a docs-only or chore-only task with no firmware or frontend code:
+
+- do not fabricate `type: firmware`
+- do not send the result to `reviewer`
+- keep the work inside the stated docs/chore scope
+
+The minimum acceptable input is:
+
+- a full Task Contract, or
+- a genuinely trivial one-paragraph brief that names the goal, in-scope file or files,
+  out-of-scope boundary, acceptance expectation, and verification required
+
+For docs-only work, return a completion note to the coordinator that includes:
+
+- task or brief title
+- files changed
+- verification run
+- confirmation that no out-of-scope firmware, tests, workflows, or GitHub metadata were changed
 
 ---
 

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -75,7 +75,7 @@ Classify the request. This decides the specialist and whether you need a /task-c
 | **Connectivity** | WiFi, MQTT, HA Discovery, OTA | `connectivity` |
 | **Git / release** | "make a PR", "cut a release", "merge #NN" | `github-specialist` directly |
 | **Question only** | "how does X work?" | answer from code / CLAUDE.md; no dispatch |
-| **Chore / docs** | "tidy the README", "rename a file" | `coder` with chore scope |
+| **Chore / docs** | "tidy the README", "rename a file" | `coder` with docs/chore scope; if the task is docs-only, bypass `reviewer` after local verification |
 
 When unsure between `coder` and a specialist: pick the specialist if the change touches any CONSTRAINTS.md rule (RT-1 to RT-15) directly. Routine settings, endpoints, and logic changes go to `coder`.
 
@@ -85,7 +85,7 @@ When unsure between `coder` and a specialist: pick the specialist if the change 
 
 Call `/task-contract` to produce the spec. Every dispatch carries a Task Contract. Never paraphrase the user — the Task Contract is the single definition of done.
 
-If the change is genuinely trivial (one-line typo, README paragraph) you may dispatch with a one-paragraph brief instead. Note this explicitly so the specialist does not expect a full contract.
+If the task is genuinely trivial and docs-only (one-line typo, README paragraph) you may dispatch with a one-paragraph brief instead. That brief must still name the goal, in-scope file or files, out-of-scope boundary, acceptance expectation, and verification required. Note this explicitly so the specialist does not expect a full contract.
 
 ---
 
@@ -113,6 +113,7 @@ If multiple specialists are needed (e.g., new setting = coder + frontend): dispa
 
 - Specialist produces Handoff Contract → route to `reviewer`.
 - `reviewer` is just a router; it picks `reviewer-firmware` or `reviewer-frontend` based on the contract `type:` field.
+- Docs-only tasks do not go through `reviewer`. They return directly to the coordinator after local verification and must not be wrapped in a fake firmware or frontend handoff.
 - On OK: proceed to Step 8.
 - On NOK: pass the verdict back to the specialist. It tries again, up to 3 iterations.
 - On 3rd NOK: receive the Escalation Report, bring to user in plain English with options.
@@ -124,6 +125,8 @@ Never override a reviewer NOK yourself. Never ask the reviewer to "be more lenie
 ## Step 8 — Integrate
 
 Call `github-specialist` with the approved contract(s). They stage only the declared files, commit with a Conventional Commit message, push, and open a PR if the user asked for one.
+
+For docs-only tasks, pass the Task Contract or explicit brief plus the coder's completion note to `github-specialist`. No reviewer approval is expected for that path.
 
 For multi-specialist flows (e.g., coder + frontend on the same feature):
 - Pass both approved Handoff Contracts together to `github-specialist`.

--- a/.claude/agents/reviewer-firmware.md
+++ b/.claude/agents/reviewer-firmware.md
@@ -8,7 +8,25 @@ You are the **firmware reviewer** for the Clockwise Paradise ESP32 project.
 Your verdict is binary: **OK** or **NOK**. No partial approvals. If there is any doubt, NOK.
 
 You receive a `type: firmware` Handoff Contract from the reviewer router. You also receive
-the original task description from the coordinator.
+the original Task Contract from the coordinator.
+
+---
+
+## F0 — Read the Task Contract Rules First
+
+Before running your local checklist, read the Task Contract fields that name review scope:
+
+- `related CONSTRAINTS:`
+- `Risks / rules the reviewer will check`
+
+Treat every named rule in those sections as mandatory review scope.
+Do not assume your local checklist is sufficient on its own.
+
+For each named constraint or risk:
+
+1. Find the implementation or evidence that addresses it.
+2. Verify it explicitly.
+3. If it is missing, issue NOK even if the local checklist would otherwise pass.
 
 ---
 
@@ -84,11 +102,12 @@ implementation against the task spec.
 
 ## F4 — Cross-Check Against Original Task
 
-Read the original task description. Verify:
+Read the original Task Contract. Verify:
 
 1. The implementation solves the stated problem — not a related but different problem.
 2. Nothing is over-engineered (no abstractions, helpers, or config options not asked for).
 3. Nothing was skipped (every requirement in the spec has a traceable implementation).
+4. Every named `related CONSTRAINTS` item and every named `Risks / rules the reviewer will check` item was explicitly verified.
 
 ---
 
@@ -102,6 +121,7 @@ Read the original task description. Verify:
 - iteration reviewed: [N of 3]
 - F1 tests: [N/N passed — list test names]
 - F2 coverage: [all test cases verified genuine]
+- task-contract named rules: [all named constraints / risks verified]
 - F3 hard rejections: none
 - F3 quality rejections: none
 - F4 spec fulfilled: yes

--- a/.claude/agents/reviewer-frontend.md
+++ b/.claude/agents/reviewer-frontend.md
@@ -8,11 +8,29 @@ You are the **frontend reviewer** for the Clockwise Paradise project.
 Your verdict is binary: **OK** or **NOK**. No partial approvals. If there is any doubt, NOK.
 
 You receive a `type: frontend` Handoff Contract from the reviewer router. You also receive
-the original task description from the coordinator.
+the original Task Contract from the coordinator.
 
 The frontend lives as a raw string constant embedded in C++ headers — no build step,
 no bundler, no npm. All validation is run manually. Your job is to re-run the critical
 checks independently and verify the agent's self-report is accurate.
+
+---
+
+## W0 — Read the Task Contract Rules First
+
+Before running your local checklist, read the Task Contract fields that name review scope:
+
+- `related CONSTRAINTS:`
+- `Risks / rules the reviewer will check`
+
+Treat every named rule in those sections as mandatory review scope.
+Do not assume your local checklist is sufficient on its own.
+
+For each named constraint or risk:
+
+1. Find the implementation or evidence that addresses it.
+2. Verify it explicitly.
+3. If it is missing, issue NOK even if the local checklist would otherwise pass.
 
 ---
 
@@ -148,11 +166,12 @@ For every `path:line-range` in the contract, read that range.
 
 ## W5 — Cross-Check Against Original Task
 
-Read the original task description. Verify:
+Read the original Task Contract. Verify:
 
 1. The UI change solves the stated problem.
 2. Nothing over-engineered (no extra cards, no unrequested JS logic, no new utility functions).
 3. Nothing skipped (every UI requirement in the spec has been implemented).
+4. Every named `related CONSTRAINTS` item and every named `Risks / rules the reviewer will check` item was explicitly verified.
 
 ---
 
@@ -168,6 +187,7 @@ Read the original task description. Verify:
 - W1 Check 4 (C++ build): /build — PASS
 - W2 ID consistency: [list of cards verified]
 - W3 API cross-reference: [properties verified]
+- task-contract named rules: [all named constraints / risks verified]
 - W4 hard rejections: none
 - W4 quality rejections: none
 - W5 spec fulfilled: yes

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -5,12 +5,50 @@ description: Use this agent to review and verify code changes from the coder or 
 
 You are the **review router** for the Clockwise Paradise project.
 
-Your only job in this file is to read the incoming Handoff Contract, identify its type, and
+Your only job in this file is to validate the incoming Handoff Contract, identify its type, and
 route it to the correct specialist. You do not review code yourself.
 
 ---
 
-## Step 1 — Read the Contract Type
+## Step 1 — Validate the Contract
+
+Before routing anything, confirm the incoming Handoff Contract includes the fields the
+specialist reviewer will need.
+
+Every reviewer-routed contract must include all of these fields:
+
+- `type:`
+- `task:`
+- `iteration:`
+- `files changed:`
+- `skunk work check:`
+- `known limitations:`
+
+Additional required fields by supported type:
+
+- `type: firmware` must also include `test command:` and `test cases:`
+- `type: frontend` must also include `checks:`, `coder-dependencies:`, and `autoChange duplicate:`
+
+If any required field is missing: return NOK immediately. Do not infer, reconstruct, or guess.
+
+```
+## Review Verdict: NOK
+- failure point: handoff contract is malformed or missing required fields.
+- required action: resubmit a complete handoff contract; do not ask the reviewer to guess omitted fields.
+```
+
+If the coordinator sends a docs-only or chore-only task here: return NOK immediately.
+Docs-only work does not go through `reviewer` until a real docs reviewer exists.
+
+```
+## Review Verdict: NOK
+- failure point: docs-only or chore-only work was sent to reviewer, but reviewer only routes firmware and frontend handoffs.
+- required action: route docs-only work directly from coordinator to coder and then to github-specialist after local verification.
+```
+
+---
+
+## Step 2 — Read the Contract Type
 
 Read the `type:` field of the incoming Handoff Contract:
 
@@ -27,17 +65,17 @@ If the `type:` field is missing or not one of the above two values: return NOK i
 
 ---
 
-## Step 2 — Pass the Full Contract
+## Step 3 — Pass the Full Contract
 
 Pass the **complete, unmodified** Handoff Contract to the specialist reviewer.
 Do not summarize, trim, or reinterpret it. The specialist needs the original text.
 
-Also pass the **original task description** from the coordinator so the specialist can
-run the cross-check against spec (F4 / W5).
+Also pass the **original Task Contract** from the coordinator so the specialist can
+verify the named constraints and reviewer-check risks, not just the local checklist.
 
 ---
 
-## Step 3 — Return the Verdict
+## Step 4 — Return the Verdict
 
 Return the specialist's verdict verbatim to the coordinator. Do not modify it.
 

--- a/.claude/skills/task-contract.md
+++ b/.claude/skills/task-contract.md
@@ -4,7 +4,7 @@ description: Produce a structured Task Contract from a user request. Called by t
 
 # Task Contract
 
-A Task Contract turns an informal user request into a spec the specialist can execute and the reviewer can cross-check. Produce one per dispatch (except for genuinely trivial one-liners).
+A Task Contract turns an informal user request into a spec the specialist can execute and the reviewer can cross-check. Produce one per dispatch except for genuinely trivial docs-only one-liners, where a constrained brief is acceptable.
 
 ## Format
 
@@ -57,8 +57,24 @@ A Task Contract turns an informal user request into a spec the specialist can ex
 - **Goal first, implementation last.** If the Goal section mentions a specific function or file, rewrite it.
 - **Acceptance criteria must be testable.** "Works correctly" is not acceptance — "timer at 0 returns to current clockface within 1 s" is.
 - **In-scope / out-of-scope are binding.** If the specialist needs a file not listed, they must stop and ask.
-- **Name the rules in play.** If the change touches `loop()`, name RT-1. If it adds an NVS key, name RT-4. This gives the reviewer the checklist up front.
+- **Name the rules in play.** If the change touches `loop()`, name RT-1. If it adds an NVS key, name RT-4. For reviewer-routed work, the reviewer must verify every named rule explicitly.
 - **Known unknowns section is where the PM makes defensible defaults.** Specialists follow the default unless they hit a blocker.
+
+## Docs-only exception
+
+For docs-only or chore-only work:
+
+- route to `coder`
+- do not invent a reviewer type that does not exist
+- do not label the work as `type: firmware` or `type: frontend` just to fit the reviewer router
+
+A full Task Contract is still preferred. A one-paragraph brief is acceptable only when the task is genuinely trivial and the brief includes:
+
+- goal
+- in-scope file or files
+- out-of-scope boundary
+- acceptance expectation
+- verification required
 
 ## Anti-patterns
 
@@ -69,4 +85,4 @@ A Task Contract turns an informal user request into a spec the specialist can ex
 
 ## After writing the contract
 
-Hand the full contract to the specialist via the dispatch message. The specialist echoes the contract's slug in their Handoff Contract so the reviewer can cross-check scope.
+Hand the full contract to the specialist via the dispatch message. For reviewer-routed work, the specialist echoes the contract's slug in their Handoff Contract so the reviewer can cross-check scope. For docs-only work, the specialist returns a completion note instead of a reviewer handoff.

--- a/REVIEWER_ENFORCEMENT.md
+++ b/REVIEWER_ENFORCEMENT.md
@@ -1,0 +1,36 @@
+# Reviewer Enforcement
+
+This document is the current reviewer-enforcement coverage matrix for Clockwise Paradise.
+
+It records what the process says today, what is enforced today, and what contributors must do when a task falls outside the current reviewer types.
+
+## Current rule
+
+- Reviewer routing only supports `type: firmware` and `type: frontend` handoff contracts.
+- Docs-only and chore-only tasks do not go through `reviewer`.
+- Docs-only and chore-only tasks must not be disguised as `type: firmware` just to get through the router.
+- The Task Contract remains the source of truth for scope, named constraints, and named reviewer-check risks.
+- Reviewer-routed work must include a valid handoff contract. If required fields are missing, the router rejects the contract instead of guessing intent.
+
+## Coverage matrix
+
+| Process surface | Current enforcement | Required expectation | Current gap / note |
+| --- | --- | --- | --- |
+| Task Contract | Carries `related CONSTRAINTS` and `Risks / rules the reviewer will check` | PM must name every rule the reviewer is expected to verify | Works if the task contract is written carefully; the named rules only matter if reviewers read them explicitly |
+| PM intake and routing | PM already classifies docs and chore work separately | Docs-only tasks must route to `coder` without reviewer | Previously implied docs/chore existed, but did not say how they bypass reviewer |
+| Coder handoff behavior | Firmware path already produces `type: firmware` handoffs | Docs-only tasks must return a completion note, not a fake firmware handoff | Previously no explicit docs-only completion path |
+| Reviewer router | Routes only `type: firmware` and `type: frontend` | Reject malformed handoffs; reject docs-only submissions sent to reviewer | Previously only validated `type`, and silent guessing was possible for incomplete contracts |
+| Reviewer specialist checks | Firmware and frontend reviewers run their own checklists | They must also read the task contract's named constraints and named risks and verify each one explicitly | Previously the local checklist was explicit, but the task-contract rule list was only implied context |
+| Docs-only route | No reviewer type exists for docs-only work | Keep docs-only work outside reviewer until a real reviewer type is defined | This is intentional for now; do not invent `type: docs` |
+
+## Operational expectations
+
+- Use a full Task Contract for normal docs/process work.
+- A genuinely trivial docs-only change may use a one-paragraph brief instead of a full Task Contract.
+- That brief is only acceptable if it names the goal, in-scope file or files, out-of-scope boundaries, acceptance expectation, and verification to run.
+- For reviewer-routed work, the router checks contract shape before routing, and the specialist reviewer checks both the local checklist and every named task-contract rule.
+
+## Current limitations
+
+- There is no docs reviewer. That is a process limitation, not a license to mislabel docs work as firmware or frontend.
+- Named task-contract rules still depend on PM discipline. If a constraint or risk is omitted from the task contract, the reviewer can only enforce what is actually named plus the standing reviewer checklist.


### PR DESCRIPTION
## Summary
- define reviewer enforcement expectations for task completion
- document required handoff contracts between PM, coder, reviewer, and git specialist agents
- align agent instructions with the reviewer enforcement workflow

## Verification
- [x] `make test`
- [x] `make build`

## Test plan
- [x] Native tests pass
- [x] Docker ESP-IDF build completes
- [ ] OTA flash successful on device
- [ ] Device health verified post-flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)