### PR TITLE
fix(night-mode): preserve brightness across state transitions

### DIFF
--- a/firmware/lib/cw-logic/core/NightModeLogic.h
+++ b/firmware/lib/cw-logic/core/NightModeLogic.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace cw {
+namespace logic {
+
+constexpr uint8_t kMinBrightDisplayOn = 4;
+constexpr uint8_t kMinBrightDisplayOff = 0;
+constexpr uint8_t kBrightnessMethodLdr = 0;
+constexpr uint8_t kBrightnessMethodTime = 1;
+constexpr uint8_t kBrightnessMethodFixed = 2;
+
+enum class NightModeTransition {
+  kStayDay,
+  kEnterNight,
+  kStayNight,
+  kExitNight,
+};
+
+struct BrightnessTarget {
+  bool hasValue;
+  uint8_t brightness;
+  int slot;
+};
+
+inline bool isNightWindow(
+  int nowHour,
+  int nowMinute,
+  int startHour,
+  int startMinute,
+  int endHour,
+  int endMinute
+) {
+  const int now = nowHour * 60 + nowMinute;
+  const int start = startHour * 60 + startMinute;
+  const int end = endHour * 60 + endMinute;
+
+  if (start < end) {
+    return now >= start && now < end;
+  }
+
+  return now >= start || now < end;
+}
+
+inline NightModeTransition resolveNightModeTransition(bool wasNightModeActive, bool inNight) {
+  if (inNight) {
+    return wasNightModeActive ? NightModeTransition::kStayNight : NightModeTransition::kEnterNight;
+  }
+
+  return wasNightModeActive ? NightModeTransition::kExitNight : NightModeTransition::kStayDay;
+}
+
+inline uint8_t resolveNightModeBrightness(uint8_t nightAction, uint8_t nightMinBrightness) {
+  return nightAction == 0 ? kMinBrightDisplayOff : nightMinBrightness;
+}
+
+inline int mapRangeClamped(int value, int inMin, int inMax, int outMin, int outMax) {
+  if (inMax <= inMin) {
+    return outMax;
+  }
+
+  if (value < inMin) value = inMin;
+  if (value > inMax) value = inMax;
+
+  const long scaled = static_cast<long>(value - inMin) * (outMax - outMin);
+  return static_cast<int>(scaled / (inMax - inMin) + outMin);
+}
+
+inline BrightnessTarget resolveLdrBrightnessTarget(
+  int currentLdrValue,
+  uint16_t ldrMin,
+  uint16_t ldrMax,
+  uint8_t displayBrightness
+) {
+  const uint8_t minBrightness =
+    currentLdrValue < static_cast<int>(ldrMin) ? kMinBrightDisplayOff : kMinBrightDisplayOn;
+  const int mappedSlot = mapRangeClamped(currentLdrValue, ldrMin, ldrMax, 1, 10);
+  const int mappedBrightness = mapRangeClamped(mappedSlot, 1, 10, minBrightness, displayBrightness);
+
+  return {true, static_cast<uint8_t>(mappedBrightness), mappedSlot};
+}
+
+inline BrightnessTarget resolveNormalBrightnessTarget(
+  uint8_t brightnessMethod,
+  bool wifiConnectedOnce,
+  bool scheduleNightActive,
+  uint8_t displayBrightness,
+  uint8_t scheduledNightBrightness,
+  int currentLdrValue,
+  uint16_t ldrMin,
+  uint16_t ldrMax
+) {
+  if (brightnessMethod == kBrightnessMethodLdr) {
+    if (ldrMax == 0) {
+      return {false, 0, -1};
+    }
+    return resolveLdrBrightnessTarget(currentLdrValue, ldrMin, ldrMax, displayBrightness);
+  }
+
+  if (brightnessMethod == kBrightnessMethodTime) {
+    if (!wifiConnectedOnce) {
+      return {false, 0, -1};
+    }
+
+    const uint8_t brightness = scheduleNightActive ? scheduledNightBrightness : displayBrightness;
+    return {true, brightness, brightness};
+  }
+
+  return {true, displayBrightness, displayBrightness};
+}
+
+inline bool shouldApplyAutomaticBrightness(
+  uint8_t brightnessMethod,
+  int currentBrightnessSlot,
+  const BrightnessTarget& target
+) {
+  if (!target.hasValue) {
+    return false;
+  }
+
+  if (brightnessMethod == kBrightnessMethodLdr) {
+    int delta = currentBrightnessSlot - target.slot;
+    if (delta < 0) delta = -delta;
+    return delta >= 2 || target.brightness == 0;
+  }
+
+  return currentBrightnessSlot != target.slot;
+}
+
+}  // namespace logic
+}  // namespace cw

--- a/firmware/src/app/core/AppState.h
+++ b/firmware/src/app/core/AppState.h
@@ -16,6 +16,7 @@ struct AppState {
   CWDateTime dateTime;
 
   unsigned long autoBrightMillis = 0;
+  int currentBrightness = -1;
   int currentBrightSlot = -1;
 
   int lastAutoChangeDay = -1;

--- a/firmware/src/app/core/DisplayControl.cpp
+++ b/firmware/src/app/core/DisplayControl.cpp
@@ -1,10 +1,10 @@
 #include "DisplayControl.h"
 
+#include <NightModeLogic.h>
+
 #include <CWPreferences.h>
 #include <esp_log.h>
 
-static constexpr uint8_t MIN_BRIGHT_DISPLAY_ON = 4;
-static constexpr uint8_t MIN_BRIGHT_DISPLAY_OFF = 0;
 static constexpr uint8_t ONBOARD_LED_PIN = 2;
 
 static bool isValidI2SSpeed(uint32_t speed) {
@@ -17,14 +17,48 @@ static bool isValidDriver(uint32_t driver) {
 
 static bool isNightTime(AppState& state) {
   auto* prefs = ClockwiseParams::getInstance();
-  int nowMins = state.dateTime.getHour() * 60 + state.dateTime.getMinute();
-  int startMins = prefs->nightStartH * 60 + prefs->nightStartM;
-  int endMins = prefs->nightEndH * 60 + prefs->nightEndM;
+  return cw::logic::isNightWindow(
+      state.dateTime.getHour(),
+      state.dateTime.getMinute(),
+      prefs->nightStartH,
+      prefs->nightStartM,
+      prefs->nightEndH,
+      prefs->nightEndM);
+}
 
-  if (startMins < endMins) {
-    return nowMins >= startMins && nowMins < endMins;
+static cw::logic::BrightnessTarget resolveCurrentNormalBrightnessTarget(AppState& state) {
+  auto* prefs = ClockwiseParams::getInstance();
+  int currentLdrValue = 0;
+  if (prefs->brightMethod == cw::logic::kBrightnessMethodLdr) {
+    currentLdrValue = analogRead(prefs->ldrPin);
   }
-  return nowMins >= startMins || nowMins < endMins;
+
+  return cw::logic::resolveNormalBrightnessTarget(
+      prefs->brightMethod,
+      state.wifi.connectionSucessfulOnce,
+      isNightTime(state),
+      prefs->displayBright,
+      prefs->nightBright,
+      currentLdrValue,
+      prefs->autoBrightMin,
+      prefs->autoBrightMax);
+}
+
+static void applyBrightnessTarget(AppState& state,
+                                  const cw::logic::BrightnessTarget& target,
+                                  bool force = false) {
+  if (!target.hasValue) {
+    return;
+  }
+
+  if (!force && state.currentBrightness == target.brightness &&
+      state.currentBrightSlot == target.slot) {
+    return;
+  }
+
+  state.display->setBrightness8(target.brightness);
+  state.currentBrightness = target.brightness;
+  state.currentBrightSlot = target.slot;
 }
 
 void displaySetup(AppState& state, uint8_t ledColorOrder, bool reversePhase,
@@ -65,6 +99,7 @@ void displaySetup(AppState& state, uint8_t ledColorOrder, bool reversePhase,
   }
 
   state.display->setBrightness8(displayBright);
+  state.currentBrightness = displayBright;
   state.display->clearScreen();
   state.display->setRotation(displayRotation);
 }
@@ -72,7 +107,7 @@ void displaySetup(AppState& state, uint8_t ledColorOrder, bool reversePhase,
 void automaticBrightControl(AppState& state) {
   auto* prefs = ClockwiseParams::getInstance();
 
-  if (prefs->brightMethod == 2) {
+  if (state.nightModeActive || prefs->brightMethod == cw::logic::kBrightnessMethodFixed) {
     return;
   }
 
@@ -81,35 +116,20 @@ void automaticBrightControl(AppState& state) {
   }
   state.autoBrightMillis = millis();
 
-  if (prefs->brightMethod == 0 && prefs->autoBrightMax > 0) {
-    int16_t currentValue = analogRead(prefs->ldrPin);
-    uint16_t ldrMin = prefs->autoBrightMin;
-    uint16_t ldrMax = prefs->autoBrightMax;
-
-    const uint8_t minBright =
-        (currentValue < ldrMin ? MIN_BRIGHT_DISPLAY_OFF : MIN_BRIGHT_DISPLAY_ON);
-    uint8_t maxBright = prefs->displayBright;
-    uint8_t slots = 10;
-    uint8_t mappedLdr =
-        map(currentValue > ldrMax ? ldrMax : currentValue, ldrMin, ldrMax, 1, slots);
-    uint8_t mappedBright = map(mappedLdr, 1, slots, minBright, maxBright);
-
-    if (abs(state.currentBrightSlot - mappedLdr) >= 2 || mappedBright == 0) {
-      state.display->setBrightness8(mappedBright);
-      state.currentBrightSlot = mappedLdr;
-    }
-  } else if (prefs->brightMethod == 1 && state.wifi.connectionSucessfulOnce) {
-    uint8_t targetBright = isNightTime(state) ? prefs->nightBright : prefs->displayBright;
-    if (state.currentBrightSlot != targetBright) {
-      state.display->setBrightness8(targetBright);
-      state.currentBrightSlot = targetBright;
-    }
+  const auto target = resolveCurrentNormalBrightnessTarget(state);
+  if (cw::logic::shouldApplyAutomaticBrightness(
+          prefs->brightMethod, state.currentBrightSlot, target)) {
+    applyBrightnessTarget(state, target);
   }
 }
 
 void nightModeCheck(AppState& state) {
   auto* prefs = ClockwiseParams::getInstance();
   if (prefs->nightMode == 0) {
+    if (state.nightModeActive) {
+      state.nightModeActive = false;
+      applyBrightnessTarget(state, resolveCurrentNormalBrightnessTarget(state), true);
+    }
     return;
   }
 
@@ -123,15 +143,20 @@ void nightModeCheck(AppState& state) {
     inNight = isNightTime(state);
   }
 
-  if (inNight && !state.nightModeActive) {
+  const auto transition =
+      cw::logic::resolveNightModeTransition(state.nightModeActive, inNight);
+  const cw::logic::BrightnessTarget nightTarget = {
+      true,
+      cw::logic::resolveNightModeBrightness(prefs->nightAction, prefs->nightMinBr),
+      -1};
+
+  if (transition == cw::logic::NightModeTransition::kEnterNight) {
     state.nightModeActive = true;
-    if (prefs->nightAction == 0) {
-      state.display->setBrightness8(0);
-    } else {
-      state.display->setBrightness8(prefs->nightMinBr);
-    }
-  } else if (!inNight && state.nightModeActive) {
+    applyBrightnessTarget(state, nightTarget, true);
+  } else if (transition == cw::logic::NightModeTransition::kStayNight) {
+    applyBrightnessTarget(state, nightTarget);
+  } else if (transition == cw::logic::NightModeTransition::kExitNight) {
     state.nightModeActive = false;
-    state.display->setBrightness8(prefs->displayBright);
+    applyBrightnessTarget(state, resolveCurrentNormalBrightnessTarget(state), true);
   }
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -87,8 +87,8 @@ void loop()
     autoChangeCheck(appState);
   }
 
-  automaticBrightControl(appState);
   nightModeCheck(appState);
+  automaticBrightControl(appState);
 
   // Keep a 1 ms yield for IDLE1; prevents loopTask watchdog panics.
   // vTaskDelay(0) does not yield on ESP-IDF v4.4.

--- a/firmware/test/test_native/SimpleTests.cpp
+++ b/firmware/test/test_native/SimpleTests.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "CWLogic.h"
+#include "NightModeLogic.h"
 
 void setUp(void) {}
 void tearDown(void) {}
@@ -58,36 +59,96 @@ void test_ota_rollback_blocked_aborted(void) {
 }
 
 // ---------------------------------------------------------------------------
-// Night window predicate — mirrors main.cpp::isNightTime() behavior
+// Night window predicate — mirrors DisplayControl night-window logic
 // ---------------------------------------------------------------------------
-static bool is_night_window(int now_h, int now_m, int start_h, int start_m, int end_h, int end_m) {
-    const int now = now_h * 60 + now_m;
-    const int start = start_h * 60 + start_m;
-    const int end = end_h * 60 + end_m;
-    if (start < end) {
-        return now >= start && now < end;
-    }
-    return now >= start || now < end;
-}
-
 void test_night_window_same_day_inside(void) {
-    TEST_ASSERT_TRUE(is_night_window(23, 0, 22, 0, 23, 59));
+    TEST_ASSERT_TRUE(cw::logic::isNightWindow(23, 0, 22, 0, 23, 59));
 }
 
 void test_night_window_same_day_outside(void) {
-    TEST_ASSERT_FALSE(is_night_window(21, 30, 22, 0, 23, 59));
+    TEST_ASSERT_FALSE(cw::logic::isNightWindow(21, 30, 22, 0, 23, 59));
 }
 
 void test_night_window_wrap_inside_evening(void) {
-    TEST_ASSERT_TRUE(is_night_window(23, 30, 22, 0, 7, 0));
+    TEST_ASSERT_TRUE(cw::logic::isNightWindow(23, 30, 22, 0, 7, 0));
 }
 
 void test_night_window_wrap_inside_morning(void) {
-    TEST_ASSERT_TRUE(is_night_window(6, 30, 22, 0, 7, 0));
+    TEST_ASSERT_TRUE(cw::logic::isNightWindow(6, 30, 22, 0, 7, 0));
 }
 
 void test_night_window_wrap_outside(void) {
-    TEST_ASSERT_FALSE(is_night_window(12, 0, 22, 0, 7, 0));
+    TEST_ASSERT_FALSE(cw::logic::isNightWindow(12, 0, 22, 0, 7, 0));
+}
+
+void test_night_mode_transition_enter(void) {
+    TEST_ASSERT_EQUAL(
+        static_cast<int>(cw::logic::NightModeTransition::kEnterNight),
+        static_cast<int>(cw::logic::resolveNightModeTransition(false, true))
+    );
+}
+
+void test_night_mode_transition_hold(void) {
+    TEST_ASSERT_EQUAL(
+        static_cast<int>(cw::logic::NightModeTransition::kStayNight),
+        static_cast<int>(cw::logic::resolveNightModeTransition(true, true))
+    );
+}
+
+void test_night_mode_transition_exit(void) {
+    TEST_ASSERT_EQUAL(
+        static_cast<int>(cw::logic::NightModeTransition::kExitNight),
+        static_cast<int>(cw::logic::resolveNightModeTransition(true, false))
+    );
+}
+
+void test_normal_brightness_target_fixed_mode(void) {
+    cw::logic::BrightnessTarget target = cw::logic::resolveNormalBrightnessTarget(
+        cw::logic::kBrightnessMethodFixed, true, false, 32, 8, 0, 0, 0);
+    TEST_ASSERT_TRUE(target.hasValue);
+    TEST_ASSERT_EQUAL_UINT8(32, target.brightness);
+    TEST_ASSERT_EQUAL(32, target.slot);
+}
+
+void test_normal_brightness_target_time_mode_uses_scheduled_night_value(void) {
+    cw::logic::BrightnessTarget target = cw::logic::resolveNormalBrightnessTarget(
+        cw::logic::kBrightnessMethodTime, true, true, 32, 8, 0, 0, 0);
+    TEST_ASSERT_TRUE(target.hasValue);
+    TEST_ASSERT_EQUAL_UINT8(8, target.brightness);
+    TEST_ASSERT_EQUAL(8, target.slot);
+}
+
+void test_normal_brightness_target_time_mode_requires_wifi(void) {
+    cw::logic::BrightnessTarget target = cw::logic::resolveNormalBrightnessTarget(
+        cw::logic::kBrightnessMethodTime, false, false, 32, 8, 0, 0, 0);
+    TEST_ASSERT_FALSE(target.hasValue);
+    TEST_ASSERT_EQUAL(-1, target.slot);
+}
+
+void test_normal_brightness_target_ldr_mode_maps_brightness(void) {
+    cw::logic::BrightnessTarget target = cw::logic::resolveNormalBrightnessTarget(
+        cw::logic::kBrightnessMethodLdr, true, false, 32, 8, 300, 100, 500);
+    TEST_ASSERT_TRUE(target.hasValue);
+    TEST_ASSERT_EQUAL(5, target.slot);
+    TEST_ASSERT_EQUAL_UINT8(16, target.brightness);
+}
+
+void test_automatic_brightness_skips_small_ldr_slot_change(void) {
+    const cw::logic::BrightnessTarget target = {true, 12, 5};
+    TEST_ASSERT_FALSE(cw::logic::shouldApplyAutomaticBrightness(
+        cw::logic::kBrightnessMethodLdr, 4, target));
+}
+
+void test_automatic_brightness_applies_large_ldr_slot_change(void) {
+    const cw::logic::BrightnessTarget target = {true, 12, 6};
+    TEST_ASSERT_TRUE(cw::logic::shouldApplyAutomaticBrightness(
+        cw::logic::kBrightnessMethodLdr, 3, target));
+}
+
+void test_automatic_brightness_applies_time_mode_change(void) {
+    const cw::logic::BrightnessTarget target = {true, 8, 8};
+    TEST_ASSERT_TRUE(cw::logic::shouldApplyAutomaticBrightness(
+        cw::logic::kBrightnessMethodTime, 32, target));
 }
 
 // ---------------------------------------------------------------------------
@@ -313,6 +374,16 @@ int runUnityTests(void) {
     RUN_TEST(test_night_window_wrap_inside_evening);
     RUN_TEST(test_night_window_wrap_inside_morning);
     RUN_TEST(test_night_window_wrap_outside);
+    RUN_TEST(test_night_mode_transition_enter);
+    RUN_TEST(test_night_mode_transition_hold);
+    RUN_TEST(test_night_mode_transition_exit);
+    RUN_TEST(test_normal_brightness_target_fixed_mode);
+    RUN_TEST(test_normal_brightness_target_time_mode_uses_scheduled_night_value);
+    RUN_TEST(test_normal_brightness_target_time_mode_requires_wifi);
+    RUN_TEST(test_normal_brightness_target_ldr_mode_maps_brightness);
+    RUN_TEST(test_automatic_brightness_skips_small_ldr_slot_change);
+    RUN_TEST(test_automatic_brightness_applies_large_ldr_slot_change);
+    RUN_TEST(test_automatic_brightness_applies_time_mode_change);
     RUN_TEST(test_url_decode_timezone);
     RUN_TEST(test_url_decode_symbols);
     RUN_TEST(test_version_normalization_equivalent);

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -11,7 +11,7 @@ idf_component_register(
 				"../firmware/src/app/widgets/ClockCore.cpp"
 				"../firmware/src/app/widgets/ClockCoreChecks.cpp"
 				"../firmware/src/CWClockfaceRegistry.cpp"
-			INCLUDE_DIRS ${PROJECT_DIR}/firmware/src
+			INCLUDE_DIRS ${PROJECT_DIR}/firmware/src ${PROJECT_DIR}/firmware/lib/cw-logic/core
 			PRIV_REQUIRES ESP32-HUB75-MatrixPanel-I2S-DMA cw-commons cw-gfx-engine WiFiManager Improv-WiFi-Library arduino Adafruit-GFX-Library esp_https_ota mqtt app_update ${CLOCKFACES}
                        )
 


### PR DESCRIPTION
## Summary
- centralize night-mode brightness decisions in shared logic to avoid stale brightness state during enter, hold, and exit transitions
- restore the correct normal brightness target after leaving night mode and prevent automatic brightness from fighting active night mode
- add native coverage for night-window, transition, and brightness-target behavior; include the new logic header in the ESP-IDF build

## Verification
- [x] make test
- [x] make build
- [ ] Hardware visual verification on device

Hardware visual verification was not run in this iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)