### PR TITLE
refactor(cw-commons): clean up web server header boundaries

### DIFF
--- a/firmware/lib/cw-commons/CWWebServer-Core.h
+++ b/firmware/lib/cw-commons/CWWebServer-Core.h
@@ -2,9 +2,7 @@
 
 #include <WiFi.h>
 #include <functional>
-#include <CWPreferences.h>
 #include "StatusController.h"
-#include "esp_log.h"
 
 #include "CWWebServer-HTTP.h"
 #include "CWWebServer-Router.h"

--- a/firmware/lib/cw-commons/CWWebServer.h
+++ b/firmware/lib/cw-commons/CWWebServer.h
@@ -1,14 +1,11 @@
 #pragma once
 
-#include <WiFi.h>
+#include <Arduino.h>
 #include <functional>
-#include <CWPreferences.h>
 
 #ifndef CLOCKFACE_NAME
   #define CLOCKFACE_NAME "UNKNOWN"
 #endif
-
-extern WiFiServer server;
 
 // Include all modular components
 #include "CWWebServer-Core.h"


### PR DESCRIPTION
## Summary
- remove unnecessary dependencies from CWWebServer public headers
- replace the top-level WiFi include with Arduino in CWWebServer.h and drop the unused global server declaration
- keep implementation details in lower-level headers so the header boundary is narrower

## Verification
- [x] make test
- [x] make build

🤖 Generated with [Claude Code](https://claude.com/claude-code)