### PR TITLE
fix(nvs): reduce redundant settings writes

### DIFF
--- a/firmware/lib/cw-commons/CWMqtt.h
+++ b/firmware/lib/cw-commons/CWMqtt.h
@@ -43,7 +43,7 @@ extern "C" {
 class CWMqtt {
 public:
     // Runtime callbacks — set by main.cpp for live control without reboot
-    std::function<void(uint8_t)> onClockfaceSwitch = nullptr;
+    std::function<bool(uint8_t)> onClockfaceSwitch = nullptr;
     std::function<bool(const String&)> onWidgetSwitch = nullptr;
     std::function<void(uint8_t)> onBrightnessChange = nullptr;
 
@@ -123,8 +123,6 @@ private:
     // ── HA MQTT Discovery ────────────────────────────────────────────────────
 
     void publishDiscovery() {
-        auto* p = ClockwiseParams::getInstance();
-
         // Device info block (shared across all entities)
         // We build it once as a JSON fragment
         String dev_str = "{\"identifiers\":[\"" + _device_id + "\"]"
@@ -250,7 +248,13 @@ private:
         } else if (prop == "clockface") {
             uint8_t idx = (uint8_t)payload.toInt();
             if (onClockfaceSwitch) {
-                onClockfaceSwitch(idx);
+                if (onClockfaceSwitch(idx)) {
+                    p->clockFaceIndex = idx;
+                    p->activeWidget = "clock";
+                    p->saveSetMutation("clockFaceIndex");
+                } else {
+                    ESP_LOGW("MQTT", "Clockface %u was rejected", idx);
+                }
             } else {
                 ESP_LOGW("MQTT", "clockface switch requested but callback not wired");
             }

--- a/firmware/lib/cw-commons/CWPreferences.h
+++ b/firmware/lib/cw-commons/CWPreferences.h
@@ -2,6 +2,8 @@
 
 #include <Preferences.h>
 
+#include "../cw-logic/core/CWLogic.h"
+
 #ifndef CW_PREF_DB_NAME
     #define CW_PREF_DB_NAME "clockwise"
 #endif
@@ -135,7 +137,39 @@ struct ClockwiseParams
     String   mqttPass;
     String   mqttPrefix;
 
-    ClockwiseParams() {
+    ClockwiseParams()
+        : swapBlueGreen(false)
+        , swapBlueRed(false)
+        , ledColorOrder(LED_ORDER_RGB)
+        , reversePhase(false)
+        , use24hFormat(true)
+        , displayBright(32)
+        , autoBrightMin(0)
+        , autoBrightMax(0)
+        , ldrPin(35)
+        , displayRotation(0)
+        , driver(0)
+        , i2cSpeed((uint32_t)8000000)
+        , E_pin(18)
+        , autoChange(AUTO_CHANGE_OFF)
+        , brightMethod(0)
+        , nightStartH(22)
+        , nightStartM(0)
+        , nightEndH(7)
+        , nightEndM(0)
+        , nightBright(8)
+        , nightMode(0)
+        , nightLevel(1)
+        , nightTrigger(0)
+        , nightLdrThres(128)
+        , nightAction(0)
+        , nightMinBr(8)
+        , superColor(16936)
+        , totalDays(0)
+        , clockFaceIndex(0)
+        , otaEnabled(true)
+        , mqttEnabled(false)
+        , mqttPort(1883) {
         preferences.begin("clockwise", false);
     }
 
@@ -205,6 +239,148 @@ struct ClockwiseParams
     void saveActiveWidget()
     {
         preferences.putString(PREF_ACTIVE_WIDGET, activeWidget);
+    }
+
+    void saveSetMutation(const String& key)
+    {
+        switch (cw::logic::resolveSetPersistenceKey(key.c_str())) {
+            case cw::logic::SetPersistenceKey::kDisplayBright:
+                preferences.putUInt(PREF_DISPLAY_BRIGHT, displayBright);
+                break;
+            case cw::logic::SetPersistenceKey::kUse24hFormat:
+                preferences.putBool(PREF_USE_24H_FORMAT, use24hFormat);
+                break;
+            case cw::logic::SetPersistenceKey::kClockFaceIndex:
+                preferences.putUChar(PREF_CLOCKFACE_INDEX, clockFaceIndex);
+                preferences.putString(PREF_ACTIVE_WIDGET, activeWidget);
+                break;
+            case cw::logic::SetPersistenceKey::kActiveWidget:
+                preferences.putString(PREF_ACTIVE_WIDGET, activeWidget);
+                break;
+            case cw::logic::SetPersistenceKey::kAutoBright:
+                preferences.putUInt(PREF_DISPLAY_ABC_MIN, autoBrightMin);
+                preferences.putUInt(PREF_DISPLAY_ABC_MAX, autoBrightMax);
+                break;
+            case cw::logic::SetPersistenceKey::kSwapBlueGreen:
+                preferences.putBool(PREF_SWAP_BLUE_GREEN, swapBlueGreen);
+                preferences.putUInt(PREF_LED_COLOR_ORDER, ledColorOrder);
+                break;
+            case cw::logic::SetPersistenceKey::kSwapBlueRed:
+                preferences.putBool(PREF_SWAP_BLUE_RED, swapBlueRed);
+                preferences.putUInt(PREF_LED_COLOR_ORDER, ledColorOrder);
+                break;
+            case cw::logic::SetPersistenceKey::kLedColorOrder:
+                preferences.putUInt(PREF_LED_COLOR_ORDER, ledColorOrder);
+                break;
+            case cw::logic::SetPersistenceKey::kAutoChange:
+                preferences.putUInt(PREF_AUTO_CHANGE, autoChange);
+                break;
+            case cw::logic::SetPersistenceKey::kLdrPin:
+                preferences.putUInt(PREF_LDR_PIN, ldrPin);
+                break;
+            case cw::logic::SetPersistenceKey::kDisplayRotation:
+                preferences.putUInt(PREF_DISPLAY_ROTATION, displayRotation);
+                break;
+            case cw::logic::SetPersistenceKey::kDriver:
+                preferences.putUInt(PREF_DRIVER, driver);
+                break;
+            case cw::logic::SetPersistenceKey::kEPin:
+                preferences.putUInt(PREF_E_PIN, E_pin);
+                break;
+            case cw::logic::SetPersistenceKey::kBrightMethod:
+                preferences.putUInt(PREF_BRIGHT_METHOD, brightMethod);
+                break;
+            case cw::logic::SetPersistenceKey::kNightStartH:
+                preferences.putUInt(PREF_NIGHT_START_H, nightStartH);
+                break;
+            case cw::logic::SetPersistenceKey::kNightStartM:
+                preferences.putUInt(PREF_NIGHT_START_M, nightStartM);
+                break;
+            case cw::logic::SetPersistenceKey::kNightEndH:
+                preferences.putUInt(PREF_NIGHT_END_H, nightEndH);
+                break;
+            case cw::logic::SetPersistenceKey::kNightEndM:
+                preferences.putUInt(PREF_NIGHT_END_M, nightEndM);
+                break;
+            case cw::logic::SetPersistenceKey::kNightBright:
+                preferences.putUInt(PREF_NIGHT_BRIGHT, nightBright);
+                break;
+            case cw::logic::SetPersistenceKey::kNightMode:
+                preferences.putUInt(PREF_NIGHT_MODE, nightMode);
+                break;
+            case cw::logic::SetPersistenceKey::kNightLevel:
+                preferences.putUInt(PREF_NIGHT_LEVEL, nightLevel);
+                break;
+            case cw::logic::SetPersistenceKey::kNightTrig:
+                preferences.putUInt(PREF_NIGHT_TRIGGER, nightTrigger);
+                break;
+            case cw::logic::SetPersistenceKey::kNightAction:
+                preferences.putUInt(PREF_NIGHT_ACTION, nightAction);
+                break;
+            case cw::logic::SetPersistenceKey::kNightMinBr:
+                preferences.putUInt(PREF_NIGHT_MIN_BRT, nightMinBr);
+                break;
+            case cw::logic::SetPersistenceKey::kSuperColor:
+                preferences.putUInt(PREF_SUPER_COLOR, superColor);
+                break;
+            case cw::logic::SetPersistenceKey::kMqttPort:
+                preferences.putUInt(PREF_MQTT_PORT, mqttPort);
+                break;
+            case cw::logic::SetPersistenceKey::kNightLdrThr:
+                preferences.putUInt(PREF_NIGHT_LDR_THRES, nightLdrThres);
+                break;
+            case cw::logic::SetPersistenceKey::kI2cSpeed:
+                preferences.putUInt(PREF_I2CSPEED, i2cSpeed);
+                break;
+            case cw::logic::SetPersistenceKey::kReversePhase:
+                preferences.putBool(PREF_REVERSE_PHASE, reversePhase);
+                break;
+            case cw::logic::SetPersistenceKey::kMqttEnabled:
+                preferences.putBool(PREF_MQTT_ENABLED, mqttEnabled);
+                break;
+            case cw::logic::SetPersistenceKey::kWifiSsid:
+                preferences.putString(PREF_WIFI_SSID, wifiSsid);
+                break;
+            case cw::logic::SetPersistenceKey::kWifiPwd:
+                preferences.putString(PREF_WIFI_PASSWORD, wifiPwd);
+                break;
+            case cw::logic::SetPersistenceKey::kTimeZone:
+                preferences.putString(PREF_TIME_ZONE, timeZone);
+                break;
+            case cw::logic::SetPersistenceKey::kNtpServer:
+                preferences.putString(PREF_NTP_SERVER, ntpServer);
+                break;
+            case cw::logic::SetPersistenceKey::kCanvasFile:
+                preferences.putString(PREF_CANVAS_FILE, canvasFile);
+                break;
+            case cw::logic::SetPersistenceKey::kCanvasServer:
+                preferences.putString(PREF_CANVAS_SERVER, canvasServer);
+                break;
+            case cw::logic::SetPersistenceKey::kManualPosix:
+                preferences.putString(PREF_MANUAL_POSIX, manualPosix);
+                break;
+            case cw::logic::SetPersistenceKey::kMqttBroker:
+                preferences.putString(PREF_MQTT_BROKER, mqttBroker);
+                break;
+            case cw::logic::SetPersistenceKey::kMqttUser:
+                preferences.putString(PREF_MQTT_USER, mqttUser);
+                break;
+            case cw::logic::SetPersistenceKey::kMqttPass:
+                preferences.putString(PREF_MQTT_PASS, mqttPass);
+                break;
+            case cw::logic::SetPersistenceKey::kMqttPrefix:
+                preferences.putString(PREF_MQTT_PREFIX, mqttPrefix);
+                break;
+            case cw::logic::SetPersistenceKey::kBigclockSrv:
+                preferences.putString(PREF_BIGCLOCK_SERVER, bigclockServer);
+                break;
+            case cw::logic::SetPersistenceKey::kBigclockFile:
+                preferences.putString(PREF_BIGCLOCK_FILE, bigclockFile);
+                break;
+            case cw::logic::SetPersistenceKey::kUnknown:
+            default:
+                break;
+        }
     }
 
     void saveTotalDays()

--- a/firmware/lib/cw-commons/CWWebServer-Config.h
+++ b/firmware/lib/cw-commons/CWWebServer-Config.h
@@ -73,7 +73,7 @@ struct CWWebServerConfig {
     const String& value,
     std::function<void(uint8_t)> onBrightnessChange,
     std::function<void(bool)> on24hFormatChange,
-    std::function<void(uint8_t)> onClockfaceSwitch,
+    std::function<bool(uint8_t)> onClockfaceSwitch,
     std::function<bool(const String&)> onWidgetSwitch,
     bool& force_restart
   ) {

--- a/firmware/lib/cw-commons/CWWebServer-Core.h
+++ b/firmware/lib/cw-commons/CWWebServer-Core.h
@@ -31,7 +31,7 @@ struct CWWebServerCore {
     bool& force_restart,
     std::function<void(uint8_t)> onBrightnessChange,
     std::function<void(bool)> on24hFormatChange,
-    std::function<void(uint8_t)> onClockfaceSwitch,
+    std::function<bool(uint8_t)> onClockfaceSwitch,
     std::function<bool(const String&)> onWidgetSwitch,
     std::function<String()> onWidgetStateJson
   ) {

--- a/firmware/lib/cw-commons/CWWebServer-Router.h
+++ b/firmware/lib/cw-commons/CWWebServer-Router.h
@@ -34,7 +34,7 @@ struct CWWebServerRouter {
     bool& force_restart,
     std::function<void(uint8_t)> onBrightnessChange,
     std::function<void(bool)> on24hFormatChange,
-    std::function<void(uint8_t)> onClockfaceSwitch,
+    std::function<bool(uint8_t)> onClockfaceSwitch,
     std::function<bool(const String&)> onWidgetSwitch,
     std::function<String()> onWidgetStateJson
   ) {
@@ -123,8 +123,18 @@ struct CWWebServerRouter {
       ClockwiseParams::getInstance()->load();
       String decodedValue = value;
       CWWebServerSettings::urlDecode(decodedValue);
-      CWWebServerSettings::handleSet(key, decodedValue, onBrightnessChange, on24hFormatChange, onClockfaceSwitch, onWidgetSwitch, force_restart);
-      ClockwiseParams::getInstance()->save();
+      CWWebServerSettings::SetApplyResult result = CWWebServerSettings::handleSet(
+        key,
+        decodedValue,
+        onBrightnessChange,
+        on24hFormatChange,
+        onClockfaceSwitch,
+        onWidgetSwitch,
+        force_restart
+      );
+      if (result == CWWebServerSettings::SetApplyResult::kPersistMutation) {
+        ClockwiseParams::getInstance()->saveSetMutation(key);
+      }
       client.println("HTTP/1.0 204 No Content");
     }
   }

--- a/firmware/lib/cw-commons/CWWebServer-Settings.h
+++ b/firmware/lib/cw-commons/CWWebServer-Settings.h
@@ -8,6 +8,12 @@
 struct CWWebServerSettings {
   static constexpr unsigned long SET_REQUEST_BODY_RECEIVE_WINDOW_MS = cw::logic::kSetRequestBodyReceiveWindowMs;
 
+  enum class SetApplyResult {
+    kRejected,
+    kPersistMutation,
+    kAlreadyPersisted,
+  };
+
   // ── Setting descriptors (pointer-to-member, type-safe) ──────────────────
   struct SettU8  { const char* k; uint8_t  ClockwiseParams::*f; };
   struct SettU16 { const char* k; uint16_t ClockwiseParams::*f; };
@@ -65,12 +71,12 @@ struct CWWebServerSettings {
    *
    * Callbacks are captured as function pointers passed from the main server instance.
    */
-  static bool handleSet(
+  static SetApplyResult handleSet(
     const String& key,
     const String& value,
     std::function<void(uint8_t)> onBrightnessChange,
     std::function<void(bool)> on24hFormatChange,
-    std::function<void(uint8_t)> onClockfaceSwitch,
+    std::function<bool(uint8_t)> onClockfaceSwitch,
     std::function<bool(const String&)> onWidgetSwitch,
     bool& force_restart
   ) {
@@ -80,20 +86,31 @@ struct CWWebServerSettings {
     if (key == "displayBright") {
       p->displayBright = (uint8_t)value.toInt();
       if (onBrightnessChange) onBrightnessChange(p->displayBright);
-      return true;
+      return SetApplyResult::kPersistMutation;
     }
     if (key == "use24hFormat") {
       p->use24hFormat = (value == "1");
       if (on24hFormatChange) on24hFormatChange(p->use24hFormat);
-      return true;
+      return SetApplyResult::kPersistMutation;
     }
     if (key == "clockFaceIndex") {
       uint8_t idx = (uint8_t)value.toInt();
+      const bool hasClockfaceSwitchCallback = static_cast<bool>(onClockfaceSwitch);
+      const bool runtimeSwitchSucceeded = !hasClockfaceSwitchCallback || onClockfaceSwitch(idx);
+
+      if (cw::logic::resolveClockfaceSetApplyDecision(hasClockfaceSwitchCallback, runtimeSwitchSucceeded)
+          == cw::logic::ClockfaceSetApplyDecision::kReject) {
+        ESP_LOGW("Web", "Clockface %u was not activated", idx);
+        return SetApplyResult::kRejected;
+      }
+
       p->clockFaceIndex = idx;
       p->activeWidget = "clock";
-      if (onClockfaceSwitch) onClockfaceSwitch(idx);
-      else force_restart = true;
-      return true;
+      if (!hasClockfaceSwitchCallback) {
+        force_restart = true;
+      }
+
+      return SetApplyResult::kPersistMutation;
     }
     if (key == "activeWidget") {
       String normalized = value;
@@ -101,18 +118,19 @@ struct CWWebServerSettings {
       if (onWidgetSwitch) {
         if (!onWidgetSwitch(normalized)) {
           ESP_LOGW("Web", "Widget '%s' not activated", normalized.c_str());
-          return false;
+          return SetApplyResult::kRejected;
         }
+        return SetApplyResult::kAlreadyPersisted;
       } else {
         p->activeWidget = normalized;
         force_restart = true;
+        return SetApplyResult::kPersistMutation;
       }
-      return true;
     }
     if (key == "autoBright") {
       p->autoBrightMin = value.substring(0, 4).toInt();
       p->autoBrightMax = value.substring(5, 9).toInt();
-      return true;
+      return SetApplyResult::kPersistMutation;
     }
     // Legacy colour swap — also updates ledColorOrder
     if (key == "swapBlueGreen") {
@@ -120,14 +138,14 @@ struct CWWebServerSettings {
       p->ledColorOrder = (value == "1") ? ClockwiseParams::LED_ORDER_RBG
                        : (p->swapBlueRed ? ClockwiseParams::LED_ORDER_GBR
                                          : ClockwiseParams::LED_ORDER_RGB);
-      return true;
+      return SetApplyResult::kPersistMutation;
     }
     if (key == "swapBlueRed") {
       p->swapBlueRed = (value == "1");
       p->ledColorOrder = (value == "1") ? ClockwiseParams::LED_ORDER_GBR
                        : (p->swapBlueGreen ? ClockwiseParams::LED_ORDER_RBG
                                            : ClockwiseParams::LED_ORDER_RGB);
-      return true;
+      return SetApplyResult::kPersistMutation;
     }
 
     // ── Table-driven simple settings ──
@@ -150,25 +168,25 @@ struct CWWebServerSettings {
       { "nightAction",     &ClockwiseParams::nightAction },
       { "nightMinBr",      &ClockwiseParams::nightMinBr },
     };
-    for (const auto& s : U8S) if (key == s.k) { p->*(s.f) = (uint8_t)value.toInt(); return true; }
+    for (const auto& s : U8S) if (key == s.k) { p->*(s.f) = (uint8_t)value.toInt(); return SetApplyResult::kPersistMutation; }
 
     static const SettU16 U16S[] = {
       { "superColor", &ClockwiseParams::superColor },
       { "mqttPort",   &ClockwiseParams::mqttPort },
       { "nightLdrThr", &ClockwiseParams::nightLdrThres },
     };
-    for (const auto& s : U16S) if (key == s.k) { p->*(s.f) = (uint16_t)value.toInt(); return true; }
+    for (const auto& s : U16S) if (key == s.k) { p->*(s.f) = (uint16_t)value.toInt(); return SetApplyResult::kPersistMutation; }
 
     static const SettU32 U32S[] = {
       { "i2cSpeed", &ClockwiseParams::i2cSpeed },
     };
-    for (const auto& s : U32S) if (key == s.k) { p->*(s.f) = (uint32_t)value.toInt(); return true; }
+    for (const auto& s : U32S) if (key == s.k) { p->*(s.f) = (uint32_t)value.toInt(); return SetApplyResult::kPersistMutation; }
 
     static const SettB BS[] = {
       { "reversePhase", &ClockwiseParams::reversePhase },
       { "mqttEnabled",  &ClockwiseParams::mqttEnabled },
     };
-    for (const auto& s : BS) if (key == s.k) { p->*(s.f) = (value == "1"); return true; }
+    for (const auto& s : BS) if (key == s.k) { p->*(s.f) = (value == "1"); return SetApplyResult::kPersistMutation; }
 
     static const SettS SS[] = {
       { "wifiSsid",     &ClockwiseParams::wifiSsid },
@@ -186,8 +204,8 @@ struct CWWebServerSettings {
       { "bigclockSrv",  &ClockwiseParams::bigclockServer },
       { "bigclockFile", &ClockwiseParams::bigclockFile },
     };
-    for (const auto& s : SS) if (key == s.k) { p->*(s.f) = value; return true; }
+    for (const auto& s : SS) if (key == s.k) { p->*(s.f) = value; return SetApplyResult::kPersistMutation; }
 
-    return false;
+    return SetApplyResult::kRejected;
   }
 };

--- a/firmware/lib/cw-commons/CWWebServer.h
+++ b/firmware/lib/cw-commons/CWWebServer.h
@@ -18,9 +18,10 @@ struct ClockwiseWebServer
   uint8_t pending_clockface_index = 255; // 255 = no pending switch
 
   // Callback set by main.cpp for live clockface switching without reboot.
-  // Signature: void switchClockface(uint8_t index)
+  // Signature: bool switchClockface(uint8_t index)
+  // Returns true when the live switch succeeded; the caller persists the change.
   // If null, falls back to save+reboot.
-  std::function<void(uint8_t)> onClockfaceSwitch = nullptr;
+  std::function<bool(uint8_t)> onClockfaceSwitch = nullptr;
   // Generic widget switch callback. Returns true if the widget was activated.
   std::function<bool(const String&)> onWidgetSwitch = nullptr;
   // Returns widget runtime state JSON.

--- a/firmware/lib/cw-logic/core/CWLogic.h
+++ b/firmware/lib/cw-logic/core/CWLogic.h
@@ -17,6 +17,58 @@ enum class SetRequestResolutionStatus {
   kRejectInvalidBody,
 };
 
+enum class SetPersistenceKey {
+  kUnknown,
+  kDisplayBright,
+  kUse24hFormat,
+  kClockFaceIndex,
+  kActiveWidget,
+  kAutoBright,
+  kSwapBlueGreen,
+  kSwapBlueRed,
+  kLedColorOrder,
+  kAutoChange,
+  kLdrPin,
+  kDisplayRotation,
+  kDriver,
+  kEPin,
+  kBrightMethod,
+  kNightStartH,
+  kNightStartM,
+  kNightEndH,
+  kNightEndM,
+  kNightBright,
+  kNightMode,
+  kNightLevel,
+  kNightTrig,
+  kNightAction,
+  kNightMinBr,
+  kSuperColor,
+  kMqttPort,
+  kNightLdrThr,
+  kI2cSpeed,
+  kReversePhase,
+  kMqttEnabled,
+  kWifiSsid,
+  kWifiPwd,
+  kTimeZone,
+  kNtpServer,
+  kCanvasFile,
+  kCanvasServer,
+  kManualPosix,
+  kMqttBroker,
+  kMqttUser,
+  kMqttPass,
+  kMqttPrefix,
+  kBigclockSrv,
+  kBigclockFile,
+};
+
+enum class ClockfaceSetApplyDecision {
+  kReject,
+  kPersistMutation,
+};
+
 struct SetRequestResolution {
   std::string key;
   std::string value;
@@ -125,6 +177,64 @@ inline std::string formUrlDecodeCopy(std::string value) {
 
 inline bool isSensitiveSetKey(const std::string& key) {
   return key == "wifiPwd" || key == "mqttPass";
+}
+
+inline SetPersistenceKey resolveSetPersistenceKey(const std::string& key) {
+  if (key == "displayBright") return SetPersistenceKey::kDisplayBright;
+  if (key == "use24hFormat") return SetPersistenceKey::kUse24hFormat;
+  if (key == "clockFaceIndex") return SetPersistenceKey::kClockFaceIndex;
+  if (key == "activeWidget") return SetPersistenceKey::kActiveWidget;
+  if (key == "autoBright") return SetPersistenceKey::kAutoBright;
+  if (key == "swapBlueGreen") return SetPersistenceKey::kSwapBlueGreen;
+  if (key == "swapBlueRed") return SetPersistenceKey::kSwapBlueRed;
+  if (key == "ledColorOrder") return SetPersistenceKey::kLedColorOrder;
+  if (key == "autoChange") return SetPersistenceKey::kAutoChange;
+  if (key == "ldrPin") return SetPersistenceKey::kLdrPin;
+  if (key == "displayRotation") return SetPersistenceKey::kDisplayRotation;
+  if (key == "driver") return SetPersistenceKey::kDriver;
+  if (key == "E_pin") return SetPersistenceKey::kEPin;
+  if (key == "brightMethod") return SetPersistenceKey::kBrightMethod;
+  if (key == "nightStartH") return SetPersistenceKey::kNightStartH;
+  if (key == "nightStartM") return SetPersistenceKey::kNightStartM;
+  if (key == "nightEndH") return SetPersistenceKey::kNightEndH;
+  if (key == "nightEndM") return SetPersistenceKey::kNightEndM;
+  if (key == "nightBright") return SetPersistenceKey::kNightBright;
+  if (key == "nightMode") return SetPersistenceKey::kNightMode;
+  if (key == "nightLevel") return SetPersistenceKey::kNightLevel;
+  if (key == "nightTrig") return SetPersistenceKey::kNightTrig;
+  if (key == "nightAction") return SetPersistenceKey::kNightAction;
+  if (key == "nightMinBr") return SetPersistenceKey::kNightMinBr;
+  if (key == "superColor") return SetPersistenceKey::kSuperColor;
+  if (key == "mqttPort") return SetPersistenceKey::kMqttPort;
+  if (key == "nightLdrThr") return SetPersistenceKey::kNightLdrThr;
+  if (key == "i2cSpeed") return SetPersistenceKey::kI2cSpeed;
+  if (key == "reversePhase") return SetPersistenceKey::kReversePhase;
+  if (key == "mqttEnabled") return SetPersistenceKey::kMqttEnabled;
+  if (key == "wifiSsid") return SetPersistenceKey::kWifiSsid;
+  if (key == "wifiPwd") return SetPersistenceKey::kWifiPwd;
+  if (key == "timeZone") return SetPersistenceKey::kTimeZone;
+  if (key == "ntpServer") return SetPersistenceKey::kNtpServer;
+  if (key == "canvasFile") return SetPersistenceKey::kCanvasFile;
+  if (key == "canvasServer") return SetPersistenceKey::kCanvasServer;
+  if (key == "manualPosix") return SetPersistenceKey::kManualPosix;
+  if (key == "mqttBroker") return SetPersistenceKey::kMqttBroker;
+  if (key == "mqttUser") return SetPersistenceKey::kMqttUser;
+  if (key == "mqttPass") return SetPersistenceKey::kMqttPass;
+  if (key == "mqttPrefix") return SetPersistenceKey::kMqttPrefix;
+  if (key == "bigclockSrv") return SetPersistenceKey::kBigclockSrv;
+  if (key == "bigclockFile") return SetPersistenceKey::kBigclockFile;
+  return SetPersistenceKey::kUnknown;
+}
+
+inline ClockfaceSetApplyDecision resolveClockfaceSetApplyDecision(
+  bool hasRuntimeSwitchCallback,
+  bool runtimeSwitchSucceeded
+) {
+  if (hasRuntimeSwitchCallback && !runtimeSwitchSucceeded) {
+    return ClockfaceSetApplyDecision::kReject;
+  }
+
+  return ClockfaceSetApplyDecision::kPersistMutation;
 }
 
 inline bool looksLikeNamedSetFormBody(const std::string& body) {

--- a/firmware/src/app/connectivity/Mqtt.cpp
+++ b/firmware/src/app/connectivity/Mqtt.cpp
@@ -5,10 +5,7 @@
 
 void bindMqttCallbacks(AppState& state) {
   CWMqtt::getInstance()->onClockfaceSwitch = [&state](uint8_t idx) {
-    if (state.widgetManager.activateClockWidget(idx)) {
-      ClockwiseParams::getInstance()->clockFaceIndex = idx;
-      ClockwiseParams::getInstance()->saveClockfaceIndex();
-    }
+    return state.widgetManager.activateClockWidget(idx);
   };
 
   CWMqtt::getInstance()->onWidgetSwitch = [&state](const String& widgetName) {

--- a/firmware/src/app/web/WebUi.cpp
+++ b/firmware/src/app/web/WebUi.cpp
@@ -5,10 +5,7 @@
 
 void bindWebUiCallbacks(AppState& state) {
   ClockwiseWebServer::getInstance()->onClockfaceSwitch = [&state](uint8_t idx) {
-    if (state.widgetManager.activateClockWidget(idx)) {
-      ClockwiseParams::getInstance()->clockFaceIndex = idx;
-      ClockwiseParams::getInstance()->saveClockfaceIndex();
-    }
+    return state.widgetManager.activateClockWidget(idx);
   };
 
   ClockwiseWebServer::getInstance()->onWidgetSwitch = [&state](const String& widgetName) {

--- a/firmware/test/test_native/SimpleTests.cpp
+++ b/firmware/test/test_native/SimpleTests.cpp
@@ -151,6 +151,48 @@ void test_sensitive_setting_detection(void) {
     TEST_ASSERT_FALSE(cw::logic::isSensitiveSetKey("wifiSsid"));
 }
 
+void test_set_persistence_key_classifies_single_value_setting(void) {
+    TEST_ASSERT_EQUAL_INT(
+        static_cast<int>(cw::logic::SetPersistenceKey::kDisplayBright),
+        static_cast<int>(cw::logic::resolveSetPersistenceKey("displayBright")));
+}
+
+void test_set_persistence_key_classifies_compound_setting(void) {
+    TEST_ASSERT_EQUAL_INT(
+        static_cast<int>(cw::logic::SetPersistenceKey::kAutoBright),
+        static_cast<int>(cw::logic::resolveSetPersistenceKey("autoBright")));
+}
+
+void test_set_persistence_key_classifies_callback_driven_setting(void) {
+    TEST_ASSERT_EQUAL_INT(
+        static_cast<int>(cw::logic::SetPersistenceKey::kClockFaceIndex),
+        static_cast<int>(cw::logic::resolveSetPersistenceKey("clockFaceIndex")));
+}
+
+void test_set_persistence_key_rejects_unknown_setting(void) {
+    TEST_ASSERT_EQUAL_INT(
+        static_cast<int>(cw::logic::SetPersistenceKey::kUnknown),
+        static_cast<int>(cw::logic::resolveSetPersistenceKey("notARealSetting")));
+}
+
+void test_clockface_set_decision_accepts_successful_runtime_switch(void) {
+    TEST_ASSERT_EQUAL_INT(
+        static_cast<int>(cw::logic::ClockfaceSetApplyDecision::kPersistMutation),
+        static_cast<int>(cw::logic::resolveClockfaceSetApplyDecision(true, true)));
+}
+
+void test_clockface_set_decision_rejects_failed_runtime_switch(void) {
+    TEST_ASSERT_EQUAL_INT(
+        static_cast<int>(cw::logic::ClockfaceSetApplyDecision::kReject),
+        static_cast<int>(cw::logic::resolveClockfaceSetApplyDecision(true, false)));
+}
+
+void test_clockface_set_decision_persists_without_runtime_callback(void) {
+    TEST_ASSERT_EQUAL_INT(
+        static_cast<int>(cw::logic::ClockfaceSetApplyDecision::kPersistMutation),
+        static_cast<int>(cw::logic::resolveClockfaceSetApplyDecision(false, false)));
+}
+
 void test_sensitive_body_overrides_query_value(void) {
     cw::logic::SetRequestResolution resolved = cw::logic::resolveSetRequest("wifiPwd", "legacy", "new%20secret", true);
     TEST_ASSERT_EQUAL(cw::logic::SetRequestResolutionStatus::kResolvedFromBody, resolved.status);
@@ -318,6 +360,13 @@ int runUnityTests(void) {
     RUN_TEST(test_version_normalization_equivalent);
     RUN_TEST(test_version_normalization_update_available);
     RUN_TEST(test_sensitive_setting_detection);
+    RUN_TEST(test_set_persistence_key_classifies_single_value_setting);
+    RUN_TEST(test_set_persistence_key_classifies_compound_setting);
+    RUN_TEST(test_set_persistence_key_classifies_callback_driven_setting);
+    RUN_TEST(test_set_persistence_key_rejects_unknown_setting);
+    RUN_TEST(test_clockface_set_decision_accepts_successful_runtime_switch);
+    RUN_TEST(test_clockface_set_decision_rejects_failed_runtime_switch);
+    RUN_TEST(test_clockface_set_decision_persists_without_runtime_callback);
     RUN_TEST(test_sensitive_body_overrides_query_value);
     RUN_TEST(test_sensitive_body_supports_form_value_with_query_key);
     RUN_TEST(test_sensitive_body_supports_key_value_form);


### PR DESCRIPTION
## Summary
- reduce targeted NVS writes by persisting only the mutated setting instead of saving the full settings set on each /set request
- align runtime callback persistence for clockface and widget changes so persisted state does not drift from the active runtime state
- add native coverage for set persistence key classification and runtime clockface apply decisions

## Verification
- make test
- make build