### PR TITLE
ci(pre-commit): add installable cppcheck hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ DIST_PART := $(DIST_DIR)/partition-table.bin
 # For flash-ota: explicit IP= on command line takes priority, falls back to DEVICE_IP from .env
 _FLASH_IP := $(or $(IP),$(DEVICE_IP))
 
-.PHONY: tools-setup tools-check pio-test test build check flash flash-ota test-hw clean help
+.PHONY: tools-setup tools-check pio-test test build check flash flash-ota test-hw install-hooks clean help
 
 ## Install pinned local developer tools in .venv-tools (platformio + cmake)
 tools-setup:
@@ -119,6 +119,15 @@ test-hw: build
 	  --bin     "$(DIST_APP)" \
 	  $(if $(PORT),--port "$(PORT)",)
 
+## Install git pre-commit hook (cppcheck on staged C++ files)
+## Run once per clone: make install-hooks
+install-hooks:
+	@hook_dir="$$(git rev-parse --git-path hooks)"; \
+	mkdir -p "$$hook_dir"; \
+	cp scripts/pre-commit "$$hook_dir/pre-commit"; \
+	chmod +x "$$hook_dir/pre-commit"; \
+	echo "pre-commit hook installed at $$hook_dir/pre-commit."
+
 ## Remove compile artifacts and the current version's dist folder
 ## (build/compile is Docker root-owned — uses sudo if plain rm fails)
 clean:
@@ -139,6 +148,7 @@ help:
 	@echo "  flash       Flash over USB   (PORT=$(PORT)  BAUD=$(BAUD))"
 	@echo "  flash-ota   Flash over Wi-Fi (DEVICE_IP or IP=<addr>)"
 	@echo "  test-hw     Build + OTA flash + hardware verification (DEVICE_IP in .env)"
+	@echo "  install-hooks Install cppcheck pre-commit hook (run once per clone)"
 	@echo "  clean       Remove build/compile and build/$(VERSION)"
 	@echo ""
 	@echo "Local config: copy .env.example -> .env and set DEVICE_IP"

--- a/README.md
+++ b/README.md
@@ -227,6 +227,31 @@ make flash PORT=/dev/ttyUSB0
 
 Or use the web flasher at [clockwise.page](https://clockwise.page) with a release `.bin`.
 
+### Pre-commit hook (static analysis)
+
+After cloning, run **once** to install the cppcheck pre-commit hook:
+
+```bash
+make install-hooks
+```
+
+The hook runs `cppcheck` on every staged `*.cpp` / `*.h` file before each commit.
+Third-party files under `components/` are automatically skipped.
+
+If the hook blocks your commit and you need to bypass it:
+
+```bash
+git commit --no-verify   # use sparingly — document the reason in the commit message
+```
+
+**Prerequisite:** `cppcheck` must be installed on your machine.
+```bash
+# Debian / Ubuntu
+sudo apt install cppcheck
+# macOS
+brew install cppcheck
+```
+
 ---
 
 ## 🔌 Flashing

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# pre-commit: run cppcheck on staged C++ files (excluding third-party components/).
+# Install once with: make install-hooks
+# Bypass (rare): git commit --no-verify
+
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+if ! command -v cppcheck >/dev/null 2>&1; then
+    echo "pre-commit: cppcheck not found — install it (apt install cppcheck) or skip with git commit --no-verify"
+    exit 1
+fi
+
+FILES=()
+while IFS= read -r -d '' path; do
+    case "$path" in
+        components/*)
+            continue
+            ;;
+        *.cpp|*.h)
+            FILES+=("$path")
+            ;;
+    esac
+done < <(git diff --cached --name-only -z --diff-filter=ACM -- '*.cpp' '*.h')
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    exit 0
+fi
+
+echo "pre-commit: running cppcheck on ${#FILES[@]} staged file(s)..."
+
+CPPCHECK_OUT=$(cppcheck \
+    --error-exitcode=1 \
+    --enable=warning \
+    --language=c++ \
+    --std=c++17 \
+    --suppress=missingIncludeSystem \
+    --quiet \
+    "${FILES[@]}" 2>&1) && RC=0 || RC=$?
+
+if [[ $RC -ne 0 ]]; then
+    echo ""
+    echo "pre-commit: cppcheck found issue(s) — commit blocked."
+    echo "-----------------------------------------------------"
+    echo "$CPPCHECK_OUT"
+    echo "-----------------------------------------------------"
+    echo "Fix the issues above, then re-stage and commit."
+    echo "To bypass (use sparingly): git commit --no-verify"
+    exit 1
+fi
+
+echo "pre-commit: cppcheck passed."
+exit 0


### PR DESCRIPTION
## Summary
- add an installable pre-commit hook that runs cppcheck on staged C++ sources and headers
- install the hook through make install-hooks using git rev-parse --git-path hooks so linked worktrees resolve the correct hooks path
- document hook installation, prerequisites, and bypass guidance in the README

## Test plan
- [x] bash -n scripts/pre-commit
- [x] make install-hooks
- [x] make test
- [x] make build
